### PR TITLE
Remove Layout component wrapper and reorder analytics components

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,3 @@
-import Layout from '@/components/layout';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -83,11 +82,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           enableSystem
           disableTransitionOnChange
         >
-          <Layout>{children}</Layout>
+          {children}
         </ThemeProvider>
         <SpeedInsights />
+        <Analytics />
       </body>
-      <Analytics />
     </html>
   );
 }


### PR DESCRIPTION
- Removed Layout component wrapper from RootLayout
- Reordered Analytics and SpeedInsights components to be inside the ThemeProvider
- Moved Analytics component to the body section instead of html section

This change simplifies the layout structure by removing an unnecessary wrapper component and ensures proper placement of analytics components within the theme provider context.