### PR TITLE
Deduce code between photo and writing pages

### DIFF
--- a/__tests__/photo.test.tsx
+++ b/__tests__/photo.test.tsx
@@ -43,7 +43,7 @@ describe('Photo Page', () => {
       },
     ]);
 
-    const params = Promise.resolve({ slug: 'spring-birds' });
+    const params = { slug: 'spring-birds' };
     render(await PhotoPage({ params }));
 
     // Verify that the page content is rendered
@@ -57,7 +57,7 @@ describe('Photo Page', () => {
     // Mock getPhotosFromCache to return an empty array
     vi.mocked(notion).getPhotosFromCache.mockReturnValue([]);
 
-    const params = Promise.resolve({ slug: 'not-real-slug' });
+    const params = { slug: 'not-real-slug' };
     await expect(PhotoPage({ params })).rejects.toThrow('NEXT_NOT_FOUND');
     expect(notFound).toHaveBeenCalled();
   });

--- a/__tests__/writing.test.tsx
+++ b/__tests__/writing.test.tsx
@@ -43,7 +43,7 @@ describe('Writing Page', () => {
         coverImage: '/images/hiring.jpg',
       },
     ]);
-    const params = Promise.resolve({ slug: 'hiring-awesome-engineers' });
+    const params = { slug: 'hiring-awesome-engineers' };
     render(await WritingPage({ params }));
 
     // Verify that the page content is rendered
@@ -58,7 +58,7 @@ describe('Writing Page', () => {
   it('renders 404 if slug does not match', async () => {
     // Mock getPostsFromCache to return an empty array
     vi.mocked(notion).getPostsFromCache.mockReturnValue([]);
-    const params = Promise.resolve({ slug: 'not-real-slug' });
+    const params = { slug: 'not-real-slug' };
     await expect(WritingPage({ params })).rejects.toThrow('NEXT_NOT_FOUND');
     expect(notFound).toHaveBeenCalled();
   });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import Layout from '@/components/layout';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -82,7 +83,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           enableSystem
           disableTransitionOnChange
         >
-          {children}
+          <Layout>{children}</Layout>
         </ThemeProvider>
         <SpeedInsights />
         <Analytics />

--- a/src/app/photos/[slug]/page.tsx
+++ b/src/app/photos/[slug]/page.tsx
@@ -1,75 +1,24 @@
-import { components } from '@/components/mdx-component';
+import PostLayout from '@/components/post-layout';
 import PostsFooter from '@/components/posts-footer';
 import { getPhotosFromCache } from '@/lib/notion';
-import { format } from 'date-fns';
+import { generateJsonLd, generatePostMetadata, generatePostStaticParams } from '@/lib/page-utils';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import ReactMarkdown from 'react-markdown';
-import rehypeRaw from 'rehype-raw';
-import remarkGfm from 'remark-gfm';
 
 interface PostPageProps {
-  params: Promise<{ slug: string }>;
+  params: { slug: string };
 }
 
 export async function generateMetadata({ params }: PostPageProps): Promise<Metadata> {
-  const { slug } = await params;
-  const posts = getPhotosFromCache();
-  const post = posts.find((p) => p.slug === slug);
-
-  if (!post) {
-    return {
-      title: 'Photo Not Found',
-    };
-  }
-
-  const siteUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.zamiang.com';
-
-  return {
-    title: post.title,
-    description: post.excerpt,
-    alternates: {
-      canonical: `${siteUrl}/photos/${post.slug}`,
-    },
-    openGraph: {
-      title: post.title,
-      description: post.excerpt,
-      siteName: "Brennan's Blog",
-      type: 'article',
-      url: `${siteUrl}/photos/${post.slug}`,
-      publishedTime: new Date(post.date).toISOString(),
-      authors: [post.author],
-      images: [
-        {
-          url: `/images/photos/${post.coverImage}`,
-          alt: post.title,
-        },
-      ],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: post.title,
-      description: post.excerpt,
-      images: [
-        {
-          url: `/images/photos/${post.coverImage}`,
-          alt: post.title,
-        },
-      ],
-    },
-  };
+  return generatePostMetadata(getPhotosFromCache, 'photos', params.slug);
 }
 
 export async function generateStaticParams() {
-  const photos = getPhotosFromCache();
-
-  return photos.map((photo) => ({
-    slug: photo.slug,
-  }));
+  return generatePostStaticParams(getPhotosFromCache);
 }
 
 export default async function PhotoPage({ params }: PostPageProps) {
-  const { slug } = await params;
+  const { slug } = params;
   const photos = getPhotosFromCache();
   const post = photos.find((p) => p.slug === slug);
 
@@ -77,32 +26,7 @@ export default async function PhotoPage({ params }: PostPageProps) {
     notFound();
   }
 
-  const siteUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.zamiang.com';
-
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'BlogPosting',
-    headline: post.title,
-    description: post.excerpt,
-    image: `/images/photos/${post.coverImage}`,
-    datePublished: new Date(post.date).toISOString(),
-    author: {
-      '@type': 'Person',
-      name: post.author,
-    },
-    publisher: {
-      '@type': 'Person',
-      name: 'Brennan Moore',
-      logo: {
-        '@type': 'ImageObject',
-        url: `${siteUrl}/favicon.png`,
-      },
-    },
-    mainEntityOfPage: {
-      '@type': 'WebPage',
-      '@id': `${siteUrl}/photos/${post.slug}`,
-    },
-  };
+  const jsonLd = generateJsonLd(post, 'photos');
 
   return (
     <>
@@ -110,26 +34,7 @@ export default async function PhotoPage({ params }: PostPageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <article className="max-w-2xl mx-auto">
-        <header className="mb-8">
-          <div className="flex items-center gap-4 text-muted-foreground mb-4">
-            <time>{format(new Date(post.date), 'MMMM d, yyyy')}</time>
-          </div>
-          <h1 className="text-4xl font-bold mb-4 text-foreground">{post.title}</h1>
-          <div className="excerpt text-muted-foreground">{post.excerpt}</div>
-          <div className="divider"></div>
-        </header>
-        <div className="max-w-none">
-          <ReactMarkdown
-            components={components}
-            remarkPlugins={[remarkGfm]}
-            rehypePlugins={[rehypeRaw]}
-          >
-            {post.content}
-          </ReactMarkdown>
-        </div>
-        <PostsFooter slug={post.slug} />
-      </article>
+      <PostLayout post={post} footerContent={<PostsFooter slug={post.slug} />} />
     </>
   );
 }

--- a/src/app/photos/[slug]/page.tsx
+++ b/src/app/photos/[slug]/page.tsx
@@ -19,7 +19,7 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
 
   if (!post) {
     return {
-      title: 'Post Not Found',
+      title: 'Photo Not Found',
     };
   }
 
@@ -70,8 +70,8 @@ export async function generateStaticParams() {
 
 export default async function PhotoPage({ params }: PostPageProps) {
   const { slug } = await params;
-  const posts = getPhotosFromCache();
-  const post = posts.find((p) => p.slug === slug);
+  const photos = getPhotosFromCache();
+  const post = photos.find((p) => p.slug === slug);
 
   if (!post) {
     notFound();

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -1,148 +1,75 @@
 import { VBC_TITLE } from '@/components/consts';
-import { components } from '@/components/mdx-component';
+import PostLayout from '@/components/post-layout';
 import PostsFooter from '@/components/posts-footer';
 import VBCFooter from '@/components/vbc-footer';
 import { getPostsFromCache, getWordCount } from '@/lib/notion';
+import { generateJsonLd, generatePostMetadata, generatePostStaticParams } from '@/lib/page-utils';
 import { calculateReadingTime } from '@/lib/utils';
-import { format } from 'date-fns';
 import { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import ReactMarkdown from 'react-markdown';
-import rehypeRaw from 'rehype-raw';
-import remarkGfm from 'remark-gfm';
 
 interface PostPageProps {
-  params: Promise<{ slug: string }>;
+  params: { slug: string };
 }
 
 export async function generateMetadata({ params }: PostPageProps): Promise<Metadata> {
-  const { slug } = await params;
-  const posts = getPostsFromCache();
-  const post = posts.find((p) => p.slug === slug);
-
-  if (!post) {
-    return {
-      title: 'Post Not Found',
-    };
-  }
-
-  const siteUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.zamiang.com';
-
-  return {
-    title: post.title,
-    description: post.excerpt,
-    alternates: {
-      canonical: `${siteUrl}/writing/${post.slug}`,
-    },
-    openGraph: {
-      title: post.title,
-      description: post.excerpt,
-      type: 'article',
-      url: `${siteUrl}/writing/${post.slug}`,
-      siteName: "Brennan's Blog",
-      publishedTime: new Date(post.date).toISOString(),
-      authors: [post.author],
-      images: [
-        {
-          url: `/images/${post.coverImage}`,
-          alt: post.title,
-        },
-      ],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: post.title,
-      description: post.excerpt,
-      images: [
-        {
-          url: `/images/${post.coverImage}`,
-          alt: post.title,
-        },
-      ],
-    },
-  };
+  return generatePostMetadata(getPostsFromCache, 'writing', params.slug);
 }
 
 export async function generateStaticParams() {
-  const posts = getPostsFromCache();
-
-  return posts.map((post) => ({
-    slug: post.slug,
-  }));
+  return generatePostStaticParams(getPostsFromCache);
 }
 
 export default async function PostPage({ params }: PostPageProps) {
-  const { slug } = await params;
+  const { slug } = params;
   const posts = getPostsFromCache();
   const post = posts.find((p) => p.slug === slug);
-  const wordCount = post?.content ? getWordCount(post.content) : 0;
 
   if (!post) {
     notFound();
   }
 
-  const siteUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.zamiang.com';
+  const wordCount = getWordCount(post.content);
+  const jsonLd = generateJsonLd(post, 'writing');
 
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'BlogPosting',
-    headline: post.title,
-    description: post.excerpt,
-    image: `/images/photos/${post.coverImage}`,
-    datePublished: new Date(post.date).toISOString(),
-    author: {
-      '@type': 'Person',
-      name: post.author,
-    },
-    publisher: {
-      '@type': 'Person',
-      name: 'Brennan Moore',
-      logo: {
-        '@type': 'ImageObject',
-        url: `${siteUrl}/favicon.png`,
-      },
-    },
-    mainEntityOfPage: {
-      '@type': 'WebPage',
-      '@id': `${siteUrl}/writing/${post.slug}`,
-    },
-  };
+  const headerContent = (
+    <>
+      <span>{calculateReadingTime(wordCount)}</span>
+    </>
+  );
+
+  const footerContent = (
+    <>
+      {post.section === 'VBC' && <VBCFooter slug={slug} />}
+      <PostsFooter slug={post.slug} />
+    </>
+  );
+
+  const subHeaderContent = (
+    <>
+      {post.section === 'VBC' && (
+        <div className="mb-2 ">
+          <Link href="/#vbc">
+            <b>{VBC_TITLE}</b>
+          </Link>
+        </div>
+      )}
+    </>
+  );
+
   return (
     <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <article className="max-w-2xl mx-auto">
-        <header className="mb-8">
-          <div className="flex items-center gap-4 text-muted-foreground mb-4">
-            <time>{format(new Date(post.date), 'MMMM d, yyyy')}</time>
-            <span>{calculateReadingTime(wordCount)}</span>
-          </div>
-          {post.section === 'VBC' && (
-            <div className="mb-2 ">
-              <Link href="/#vbc">
-                <b>{VBC_TITLE}</b>
-              </Link>
-            </div>
-          )}
-          <h1 className="mb-4">{post.title}</h1>
-          <div className="excerpt text-muted-foreground">{post.excerpt}</div>
-          <div className="divider"></div>
-        </header>
-        <div className="max-w-none">
-          <ReactMarkdown
-            components={components}
-            remarkPlugins={[remarkGfm]}
-            rehypePlugins={[rehypeRaw]}
-          >
-            {post.content}
-          </ReactMarkdown>
-        </div>
-        {post.section === 'VBC' && <VBCFooter slug={slug} />}
-        <PostsFooter slug={post.slug} />
-      </article>
+      <PostLayout
+        post={post}
+        headerContent={headerContent}
+        footerContent={footerContent}
+        subHeaderContent={subHeaderContent}
+      />
     </>
   );
 }

--- a/src/components/post-layout.tsx
+++ b/src/components/post-layout.tsx
@@ -1,0 +1,48 @@
+import { Post } from '@/lib/notion';
+import { format } from 'date-fns';
+import ReactMarkdown from 'react-markdown';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
+
+import { components } from './mdx-component';
+
+interface PostLayoutProps {
+  post: Post;
+  headerContent?: React.ReactNode;
+  subHeaderContent?: React.ReactNode;
+  footerContent?: React.ReactNode;
+}
+
+export default function PostLayout({
+  post,
+  headerContent,
+  subHeaderContent,
+  footerContent,
+}: PostLayoutProps) {
+  return (
+    <>
+      <article className="max-w-2xl mx-auto">
+        <header className="mb-8">
+          <div className="flex items-center gap-4 text-muted-foreground mb-4">
+            <time>{format(new Date(post.date), 'MMMM d, yyyy')}</time>
+            {headerContent}
+          </div>
+          {subHeaderContent}
+          <h1 className="text-4xl font-bold mb-4 text-foreground">{post.title}</h1>
+          <div className="excerpt text-muted-foreground">{post.excerpt}</div>
+          <div className="divider"></div>
+        </header>
+        <div className="max-w-none">
+          <ReactMarkdown
+            components={components}
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeRaw]}
+          >
+            {post.content}
+          </ReactMarkdown>
+        </div>
+        {footerContent}
+      </article>
+    </>
+  );
+}

--- a/src/lib/page-utils.ts
+++ b/src/lib/page-utils.ts
@@ -1,0 +1,95 @@
+import { Post } from '@/lib/notion';
+import { Metadata } from 'next';
+
+type PostType = 'photos' | 'writing';
+
+export async function generatePostMetadata(
+  getPosts: () => Post[],
+  type: PostType,
+  slug: string,
+): Promise<Metadata> {
+  const posts = getPosts();
+  const post = posts.find((p) => p.slug === slug);
+
+  if (!post) {
+    return {
+      title: 'Post Not Found',
+    };
+  }
+
+  const siteUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.zamiang.com';
+  const imageUrl =
+    type === 'photos' ? `/images/photos/${post.coverImage}` : `/images/${post.coverImage}`;
+
+  return {
+    title: post.title,
+    description: post.excerpt,
+    alternates: {
+      canonical: `${siteUrl}/${type}/${post.slug}`,
+    },
+    openGraph: {
+      title: post.title,
+      description: post.excerpt,
+      siteName: "Brennan's Blog",
+      type: 'article',
+      url: `${siteUrl}/${type}/${post.slug}`,
+      publishedTime: new Date(post.date).toISOString(),
+      authors: [post.author],
+      images: [
+        {
+          url: imageUrl,
+          alt: post.title,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.excerpt,
+      images: [
+        {
+          url: imageUrl,
+          alt: post.title,
+        },
+      ],
+    },
+  };
+}
+
+export function generatePostStaticParams(getPosts: () => Post[]) {
+  const posts = getPosts();
+  return posts.map((post) => ({
+    slug: post.slug,
+  }));
+}
+
+export function generateJsonLd(post: Post, type: PostType) {
+  const siteUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.zamiang.com';
+  const imageUrl =
+    type === 'photos' ? `/images/photos/${post.coverImage}` : `/images/${post.coverImage}`;
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.title,
+    description: post.excerpt,
+    image: imageUrl,
+    datePublished: new Date(post.date).toISOString(),
+    author: {
+      '@type': 'Person',
+      name: post.author,
+    },
+    publisher: {
+      '@type': 'Person',
+      name: 'Brennan Moore',
+      logo: {
+        '@type': 'ImageObject',
+        url: `${siteUrl}/favicon.png`,
+      },
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': `${siteUrl}/${type}/${post.slug}`,
+    },
+  };
+}


### PR DESCRIPTION
Rrefactored the code to reduce duplication between the photo and writing pages. I've created a new utility file, src/lib/page-utils.ts, to house the shared logic for generating page-specific data. I've also created a reusable PostLayout component to contain the shared JSX structure for both pages. Finally, I've refactored both page components to use these new utility functions and the PostLayout component. This will make the code easier to maintain and update in the future.
