### PR TITLE
Simplify Work section to resume-style layout

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -139,7 +139,7 @@ const jsonLd = {
         <div class="work-card">
           <div class="work-card-header">
             <time class="work-card-date">2022–2025</time>
-            <span class="work-card-sep">&middot;</span>
+            <span class="work-card-sep" aria-hidden="true">&middot;</span>
             <span class="work-card-role">CTO</span>
           </div>
           <h3 class="work-card-title">
@@ -157,7 +157,7 @@ const jsonLd = {
         <div class="work-card">
           <div class="work-card-header">
             <time class="work-card-date">2022–2026</time>
-            <span class="work-card-sep">&middot;</span>
+            <span class="work-card-sep" aria-hidden="true">&middot;</span>
             <span class="work-card-role">Founder</span>
           </div>
           <h3 class="work-card-title">
@@ -176,7 +176,7 @@ const jsonLd = {
         <div class="work-card">
           <div class="work-card-header">
             <time class="work-card-date">2017–2021</time>
-            <span class="work-card-sep">&middot;</span>
+            <span class="work-card-sep" aria-hidden="true">&middot;</span>
             <span class="work-card-role">Founding Engineer</span>
           </div>
           <h3 class="work-card-title">
@@ -194,7 +194,7 @@ const jsonLd = {
         <div class="work-card">
           <div class="work-card-header">
             <time class="work-card-date">2009–2015</time>
-            <span class="work-card-sep">&middot;</span>
+            <span class="work-card-sep" aria-hidden="true">&middot;</span>
             <span class="work-card-role">Lots of projects</span>
           </div>
           <h3 class="work-card-title">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -139,6 +139,7 @@ const jsonLd = {
         <div class="work-card">
           <div class="work-card-header">
             <time class="work-card-date">2022–2025</time>
+            <span class="work-card-sep">&middot;</span>
             <span class="work-card-role">CTO</span>
           </div>
           <h3 class="work-card-title">
@@ -156,6 +157,7 @@ const jsonLd = {
         <div class="work-card">
           <div class="work-card-header">
             <time class="work-card-date">2022–2026</time>
+            <span class="work-card-sep">&middot;</span>
             <span class="work-card-role">Founder</span>
           </div>
           <h3 class="work-card-title">
@@ -174,6 +176,7 @@ const jsonLd = {
         <div class="work-card">
           <div class="work-card-header">
             <time class="work-card-date">2017–2021</time>
+            <span class="work-card-sep">&middot;</span>
             <span class="work-card-role">Founding Engineer</span>
           </div>
           <h3 class="work-card-title">
@@ -191,6 +194,7 @@ const jsonLd = {
         <div class="work-card">
           <div class="work-card-header">
             <time class="work-card-date">2009–2015</time>
+            <span class="work-card-sep">&middot;</span>
             <span class="work-card-role">Lots of projects</span>
           </div>
           <h3 class="work-card-title">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -858,8 +858,7 @@
   }
 
   .work-card-sep {
-    color: var(--muted-foreground);
-    opacity: 0.4;
+    color: color-mix(in srgb, var(--muted-foreground) 40%, transparent);
   }
 
   .work-card-role {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -833,26 +833,20 @@
   /* Work Cards - Career timeline items */
   .work-card {
     position: relative;
-    padding: 1.5rem;
-    margin-bottom: 1rem;
-    background: rgba(255, 255, 255, 0.5);
-    border: 1px solid rgba(209, 213, 219, 0.4);
-    border-radius: 8px;
-    transition:
-      background-color var(--transition-normal) var(--ease-out),
-      border-color var(--transition-normal) var(--ease-out);
+    padding: 1.25rem 0;
+    margin-bottom: 0;
+    border-bottom: 1px solid rgba(209, 213, 219, 0.5);
   }
 
-  .work-card:hover {
-    background: rgba(255, 255, 255, 0.7);
-    border-color: rgba(116, 156, 168, 0.4);
+  .work-card:last-of-type {
+    border-bottom: none;
   }
 
   .work-card-header {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
-    margin-bottom: 0.5rem;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
   }
 
   .work-card-date {
@@ -863,6 +857,11 @@
     letter-spacing: 0.05em;
   }
 
+  .work-card-sep {
+    color: var(--muted-foreground);
+    opacity: 0.4;
+  }
+
   .work-card-role {
     font-family: var(--font-sans);
     font-size: clamp(
@@ -870,13 +869,8 @@
       0.65rem + 0.1vw,
       0.75rem
     ); /* Fluid: 11-12px - improved readability */
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em; /* Tightened for better legibility at small sizes */
+    font-weight: 500;
     color: var(--muted-foreground);
-    background: color-mix(in srgb, var(--accent) 15%, transparent);
-    padding: 0.25rem 0.625rem;
-    border-radius: 4px;
   }
 
   .work-card-title {


### PR DESCRIPTION
## Summary
- Remove card borders, backgrounds, border-radius, and hover effects from work items
- Replace with subtle bottom dividers between entries for a cleaner resume-like feel
- Simplify role badge from pill/uppercase to plain inline text with a `·` separator
- Tighten spacing for a more compact, professional layout

## Test plan
- [ ] Verify work section renders without card borders/backgrounds
- [ ] Check bottom dividers appear between items but not after the last one
- [ ] Confirm role text displays inline with date and dot separator
- [ ] Test on mobile viewport for proper spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)