### PR TITLE
Add markdown alternate endpoints for AI agents

### DIFF
--- a/__tests__/pages/photos-markdown.test.ts
+++ b/__tests__/pages/photos-markdown.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+
+import { config } from '@/lib/config';
+
+/**
+ * Tests for the photos markdown endpoint.
+ *
+ * Since the endpoint uses astro:content (a virtual module), we can't import
+ * it directly in vitest. Instead, we test the response-building logic directly.
+ */
+
+interface PhotoData {
+  title: string;
+  slug: string;
+  date: string;
+  excerpt?: string;
+  content: string;
+  author: string;
+  coverImage: string;
+}
+
+/**
+ * Mirrors the GET handler logic from src/pages/photos/[slug].md.ts
+ */
+function buildMarkdownResponse(post: PhotoData): Response {
+  const siteUrl = config.site.url;
+  const canonicalUrl = `${siteUrl}/photos/${post.slug}`;
+
+  const lines = [
+    '---',
+    `title: "${post.title.replace(/"/g, '\\"')}"`,
+    `date: "${post.date}"`,
+    `author: "${post.author}"`,
+    `canonical_url: "${canonicalUrl}"`,
+  ];
+
+  if (post.excerpt) {
+    lines.push(`excerpt: "${post.excerpt.replace(/"/g, '\\"')}"`);
+  }
+
+  lines.push('---', '', `# ${post.title}`, '', post.content);
+
+  return new Response(lines.join('\n'), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+    },
+  });
+}
+
+function createMockPhoto(overrides: Partial<PhotoData> = {}): PhotoData {
+  return {
+    title: 'Sunset in Brooklyn',
+    slug: 'sunset-in-brooklyn',
+    date: '2025-03-10',
+    author: 'Brennan Moore',
+    content: 'A beautiful sunset over the Brooklyn Bridge.',
+    excerpt: 'Sunset photography',
+    coverImage: 'sunset.jpg',
+    ...overrides,
+  };
+}
+
+describe('Photos Markdown Endpoint', () => {
+  describe('response headers', () => {
+    it('should return text/markdown content type', async () => {
+      const response = buildMarkdownResponse(createMockPhoto());
+
+      expect(response.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8');
+    });
+
+    it('should include cache-control headers', async () => {
+      const response = buildMarkdownResponse(createMockPhoto());
+
+      expect(response.headers.get('Cache-Control')).toBe(
+        'public, max-age=3600, stale-while-revalidate=86400',
+      );
+    });
+  });
+
+  describe('frontmatter', () => {
+    it('should include required fields', async () => {
+      const response = buildMarkdownResponse(createMockPhoto());
+      const body = await response.text();
+
+      expect(body).toMatch(/^---\n/);
+      expect(body).toContain('title: "Sunset in Brooklyn"');
+      expect(body).toContain('date: "2025-03-10"');
+      expect(body).toContain('author: "Brennan Moore"');
+    });
+
+    it('should include excerpt when present', async () => {
+      const response = buildMarkdownResponse(createMockPhoto({ excerpt: 'Photo description' }));
+      const body = await response.text();
+
+      expect(body).toContain('excerpt: "Photo description"');
+    });
+
+    it('should omit excerpt when not present', async () => {
+      const response = buildMarkdownResponse(createMockPhoto({ excerpt: undefined }));
+      const body = await response.text();
+
+      expect(body).not.toContain('excerpt:');
+    });
+
+    it('should escape double quotes in title', async () => {
+      const response = buildMarkdownResponse(
+        createMockPhoto({ title: 'The "Golden" Hour' }),
+      );
+      const body = await response.text();
+
+      expect(body).toContain('title: "The \\"Golden\\" Hour"');
+    });
+
+    it('should escape double quotes in excerpt', async () => {
+      const response = buildMarkdownResponse(
+        createMockPhoto({ excerpt: 'A "dreamy" scene' }),
+      );
+      const body = await response.text();
+
+      expect(body).toContain('excerpt: "A \\"dreamy\\" scene"');
+    });
+  });
+
+  describe('canonical URL', () => {
+    it('should use /photos/ path prefix', async () => {
+      const response = buildMarkdownResponse(createMockPhoto({ slug: 'my-photo' }));
+      const body = await response.text();
+
+      expect(body).toContain('canonical_url: "https://www.zamiang.com/photos/my-photo"');
+    });
+  });
+
+  describe('body content', () => {
+    it('should include the photo title as an h1 heading', async () => {
+      const response = buildMarkdownResponse(createMockPhoto({ title: 'NYC at Dusk' }));
+      const body = await response.text();
+
+      expect(body).toContain('\n# NYC at Dusk\n');
+    });
+
+    it('should include the full markdown content', async () => {
+      const content = 'Shot on a Fujifilm X-T5 with the 23mm f/1.4.\n\nGolden hour light.';
+      const response = buildMarkdownResponse(createMockPhoto({ content }));
+      const body = await response.text();
+
+      expect(body).toContain(content);
+    });
+
+    it('should structure output as frontmatter → heading → content', async () => {
+      const response = buildMarkdownResponse(
+        createMockPhoto({
+          title: 'My Photo',
+          content: 'Photo description here.',
+        }),
+      );
+      const body = await response.text();
+
+      const parts = body.split('---');
+      expect(parts).toHaveLength(3);
+
+      const afterFrontmatter = parts[2];
+      expect(afterFrontmatter).toMatch(/\n\n# My Photo\n\nPhoto description here\./);
+    });
+  });
+});

--- a/__tests__/pages/photos-markdown.test.ts
+++ b/__tests__/pages/photos-markdown.test.ts
@@ -1,54 +1,8 @@
+import { config } from '@/lib/config';
+import { type MarkdownPostData, buildMarkdownResponse } from '@/lib/markdown-response';
 import { describe, expect, it } from 'vitest';
 
-import { config } from '@/lib/config';
-
-/**
- * Tests for the photos markdown endpoint.
- *
- * Since the endpoint uses astro:content (a virtual module), we can't import
- * it directly in vitest. Instead, we test the response-building logic directly.
- */
-
-interface PhotoData {
-  title: string;
-  slug: string;
-  date: string;
-  excerpt?: string;
-  content: string;
-  author: string;
-  coverImage: string;
-}
-
-/**
- * Mirrors the GET handler logic from src/pages/photos/[slug].md.ts
- */
-function buildMarkdownResponse(post: PhotoData): Response {
-  const siteUrl = config.site.url;
-  const canonicalUrl = `${siteUrl}/photos/${post.slug}`;
-
-  const lines = [
-    '---',
-    `title: "${post.title.replace(/"/g, '\\"')}"`,
-    `date: "${post.date}"`,
-    `author: "${post.author}"`,
-    `canonical_url: "${canonicalUrl}"`,
-  ];
-
-  if (post.excerpt) {
-    lines.push(`excerpt: "${post.excerpt.replace(/"/g, '\\"')}"`);
-  }
-
-  lines.push('---', '', `# ${post.title}`, '', post.content);
-
-  return new Response(lines.join('\n'), {
-    headers: {
-      'Content-Type': 'text/markdown; charset=utf-8',
-      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
-    },
-  });
-}
-
-function createMockPhoto(overrides: Partial<PhotoData> = {}): PhotoData {
+function createMockPhoto(overrides: Partial<MarkdownPostData> = {}): MarkdownPostData {
   return {
     title: 'Sunset in Brooklyn',
     slug: 'sunset-in-brooklyn',
@@ -56,21 +10,24 @@ function createMockPhoto(overrides: Partial<PhotoData> = {}): PhotoData {
     author: 'Brennan Moore',
     content: 'A beautiful sunset over the Brooklyn Bridge.',
     excerpt: 'Sunset photography',
-    coverImage: 'sunset.jpg',
     ...overrides,
   };
+}
+
+function buildPhotoResponse(post: MarkdownPostData): Response {
+  return buildMarkdownResponse(post, 'photos', config.site.url);
 }
 
 describe('Photos Markdown Endpoint', () => {
   describe('response headers', () => {
     it('should return text/markdown content type', async () => {
-      const response = buildMarkdownResponse(createMockPhoto());
+      const response = buildPhotoResponse(createMockPhoto());
 
       expect(response.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8');
     });
 
     it('should include cache-control headers', async () => {
-      const response = buildMarkdownResponse(createMockPhoto());
+      const response = buildPhotoResponse(createMockPhoto());
 
       expect(response.headers.get('Cache-Control')).toBe(
         'public, max-age=3600, stale-while-revalidate=86400',
@@ -80,7 +37,7 @@ describe('Photos Markdown Endpoint', () => {
 
   describe('frontmatter', () => {
     it('should include required fields', async () => {
-      const response = buildMarkdownResponse(createMockPhoto());
+      const response = buildPhotoResponse(createMockPhoto());
       const body = await response.text();
 
       expect(body).toMatch(/^---\n/);
@@ -90,41 +47,44 @@ describe('Photos Markdown Endpoint', () => {
     });
 
     it('should include excerpt when present', async () => {
-      const response = buildMarkdownResponse(createMockPhoto({ excerpt: 'Photo description' }));
+      const response = buildPhotoResponse(createMockPhoto({ excerpt: 'Photo description' }));
       const body = await response.text();
 
       expect(body).toContain('excerpt: "Photo description"');
     });
 
     it('should omit excerpt when not present', async () => {
-      const response = buildMarkdownResponse(createMockPhoto({ excerpt: undefined }));
+      const response = buildPhotoResponse(createMockPhoto({ excerpt: undefined }));
       const body = await response.text();
 
       expect(body).not.toContain('excerpt:');
     });
 
     it('should escape double quotes in title', async () => {
-      const response = buildMarkdownResponse(
-        createMockPhoto({ title: 'The "Golden" Hour' }),
-      );
+      const response = buildPhotoResponse(createMockPhoto({ title: 'The "Golden" Hour' }));
       const body = await response.text();
 
       expect(body).toContain('title: "The \\"Golden\\" Hour"');
     });
 
     it('should escape double quotes in excerpt', async () => {
-      const response = buildMarkdownResponse(
-        createMockPhoto({ excerpt: 'A "dreamy" scene' }),
-      );
+      const response = buildPhotoResponse(createMockPhoto({ excerpt: 'A "dreamy" scene' }));
       const body = await response.text();
 
       expect(body).toContain('excerpt: "A \\"dreamy\\" scene"');
+    });
+
+    it('should escape backslashes in title', async () => {
+      const response = buildPhotoResponse(createMockPhoto({ title: 'Path\\to\\photo' }));
+      const body = await response.text();
+
+      expect(body).toContain('title: "Path\\\\to\\\\photo"');
     });
   });
 
   describe('canonical URL', () => {
     it('should use /photos/ path prefix', async () => {
-      const response = buildMarkdownResponse(createMockPhoto({ slug: 'my-photo' }));
+      const response = buildPhotoResponse(createMockPhoto({ slug: 'my-photo' }));
       const body = await response.text();
 
       expect(body).toContain('canonical_url: "https://www.zamiang.com/photos/my-photo"');
@@ -133,7 +93,7 @@ describe('Photos Markdown Endpoint', () => {
 
   describe('body content', () => {
     it('should include the photo title as an h1 heading', async () => {
-      const response = buildMarkdownResponse(createMockPhoto({ title: 'NYC at Dusk' }));
+      const response = buildPhotoResponse(createMockPhoto({ title: 'NYC at Dusk' }));
       const body = await response.text();
 
       expect(body).toContain('\n# NYC at Dusk\n');
@@ -141,14 +101,14 @@ describe('Photos Markdown Endpoint', () => {
 
     it('should include the full markdown content', async () => {
       const content = 'Shot on a Fujifilm X-T5 with the 23mm f/1.4.\n\nGolden hour light.';
-      const response = buildMarkdownResponse(createMockPhoto({ content }));
+      const response = buildPhotoResponse(createMockPhoto({ content }));
       const body = await response.text();
 
       expect(body).toContain(content);
     });
 
     it('should structure output as frontmatter → heading → content', async () => {
-      const response = buildMarkdownResponse(
+      const response = buildPhotoResponse(
         createMockPhoto({
           title: 'My Photo',
           content: 'Photo description here.',

--- a/__tests__/pages/photos-markdown.test.ts
+++ b/__tests__/pages/photos-markdown.test.ts
@@ -80,6 +80,13 @@ describe('Photos Markdown Endpoint', () => {
 
       expect(body).toContain('title: "Path\\\\to\\\\photo"');
     });
+
+    it('should escape newlines in excerpt', async () => {
+      const response = buildPhotoResponse(createMockPhoto({ excerpt: 'Line one\nLine two' }));
+      const body = await response.text();
+
+      expect(body).toContain('excerpt: "Line one\\nLine two"');
+    });
   });
 
   describe('canonical URL', () => {

--- a/__tests__/pages/writing-markdown.test.ts
+++ b/__tests__/pages/writing-markdown.test.ts
@@ -114,6 +114,13 @@ describe('Writing Markdown Endpoint', () => {
       expect(body).toContain('title: "The \\\\n (newline)"');
     });
 
+    it('should escape the date field', async () => {
+      const response = buildWritingResponse(createMockPost({ date: '2025-06-15' }));
+      const body = await response.text();
+
+      expect(body).toContain('date: "2025-06-15"');
+    });
+
     it('should escape backslashes before quotes', async () => {
       const response = buildWritingResponse(createMockPost({ title: 'path\\to\\"file"' }));
       const body = await response.text();
@@ -128,6 +135,16 @@ describe('Writing Markdown Endpoint', () => {
       const body = await response.text();
 
       expect(body).toContain('\n# My Great Post\n');
+    });
+
+    it('should escape markdown syntax in the h1 title', async () => {
+      const response = buildWritingResponse(
+        createMockPost({ title: 'Lessons from "The **Hard** Way"' }),
+      );
+      const body = await response.text();
+
+      // Bold markers should be escaped so they render literally
+      expect(body).toContain('# Lessons from "The \\*\\*Hard\\*\\* Way"');
     });
 
     it('should include the full markdown content', async () => {

--- a/__tests__/pages/writing-markdown.test.ts
+++ b/__tests__/pages/writing-markdown.test.ts
@@ -1,5 +1,10 @@
 import { config } from '@/lib/config';
-import { type MarkdownPostData, buildMarkdownResponse } from '@/lib/markdown-response';
+import {
+  type MarkdownPostData,
+  buildMarkdownResponse,
+  escapeYamlString,
+  toMarkdownPostData,
+} from '@/lib/markdown-response';
 import { describe, expect, it } from 'vitest';
 
 function createMockPost(overrides: Partial<MarkdownPostData> = {}): MarkdownPostData {
@@ -164,5 +169,85 @@ describe('Writing Markdown Endpoint', () => {
 
       expect(body).toContain(`canonical_url: "${config.site.url}/writing/`);
     });
+  });
+});
+
+describe('escapeYamlString', () => {
+  it('should escape backslashes', () => {
+    expect(escapeYamlString('a\\b')).toBe('a\\\\b');
+  });
+
+  it('should escape double quotes', () => {
+    expect(escapeYamlString('say "hello"')).toBe('say \\"hello\\"');
+  });
+
+  it('should escape newlines', () => {
+    expect(escapeYamlString('line1\nline2')).toBe('line1\\nline2');
+  });
+
+  it('should escape carriage returns', () => {
+    expect(escapeYamlString('line1\rline2')).toBe('line1\\rline2');
+  });
+
+  it('should escape tabs', () => {
+    expect(escapeYamlString('col1\tcol2')).toBe('col1\\tcol2');
+  });
+
+  it('should escape backslashes before other characters', () => {
+    // Backslash followed by quote: \ then " → \\ then \"
+    expect(escapeYamlString('\\"')).toBe('\\\\\\"');
+  });
+
+  it('should handle strings with no special characters', () => {
+    expect(escapeYamlString('plain text')).toBe('plain text');
+  });
+});
+
+describe('toMarkdownPostData', () => {
+  it('should map all fields from raw data', () => {
+    const raw = {
+      title: 'My Post',
+      slug: 'my-post',
+      date: '2025-01-01',
+      author: 'Author',
+      content: 'Content here',
+      excerpt: 'Excerpt',
+      section: 'VBC',
+    };
+    const result = toMarkdownPostData(raw);
+
+    expect(result).toEqual(raw);
+  });
+
+  it('should default title to "Untitled" when missing', () => {
+    const result = toMarkdownPostData({});
+    expect(result.title).toBe('Untitled');
+  });
+
+  it('should default string fields to empty string when missing', () => {
+    const result = toMarkdownPostData({});
+    expect(result.slug).toBe('');
+    expect(result.date).toBe('');
+    expect(result.author).toBe('');
+    expect(result.content).toBe('');
+  });
+
+  it('should set optional fields to undefined when missing', () => {
+    const result = toMarkdownPostData({ title: 'Test' });
+    expect(result.excerpt).toBeUndefined();
+    expect(result.section).toBeUndefined();
+  });
+
+  it('should coerce null values to defaults', () => {
+    const result = toMarkdownPostData({ title: null, slug: null, excerpt: null });
+    expect(result.title).toBe('Untitled');
+    expect(result.slug).toBe('');
+    expect(result.excerpt).toBeUndefined();
+  });
+
+  it('should coerce numeric values to strings', () => {
+    const result = toMarkdownPostData({ title: 42, slug: 123 });
+    expect(result.title).toBe('42');
+    expect(result.slug).toBe('123');
   });
 });

--- a/__tests__/pages/writing-markdown.test.ts
+++ b/__tests__/pages/writing-markdown.test.ts
@@ -1,59 +1,8 @@
+import { config } from '@/lib/config';
+import { type MarkdownPostData, buildMarkdownResponse } from '@/lib/markdown-response';
 import { describe, expect, it } from 'vitest';
 
-import { config } from '@/lib/config';
-
-/**
- * Tests for the writing markdown endpoint.
- *
- * Since the endpoint uses astro:content (a virtual module), we can't import
- * it directly in vitest. Instead, we extract and test the response-building
- * logic directly, which is the core of the GET handler.
- */
-
-interface PostData {
-  title: string;
-  slug: string;
-  date: string;
-  excerpt?: string;
-  content: string;
-  author: string;
-  section?: string;
-}
-
-/**
- * Mirrors the GET handler logic from src/pages/writing/[slug].md.ts
- * so we can test the markdown output without Astro's virtual modules.
- */
-function buildMarkdownResponse(post: PostData): Response {
-  const siteUrl = config.site.url;
-  const canonicalUrl = `${siteUrl}/writing/${post.slug}`;
-
-  const lines = [
-    '---',
-    `title: "${post.title.replace(/"/g, '\\"')}"`,
-    `date: "${post.date}"`,
-    `author: "${post.author}"`,
-    `canonical_url: "${canonicalUrl}"`,
-  ];
-
-  if (post.excerpt) {
-    lines.push(`excerpt: "${post.excerpt.replace(/"/g, '\\"')}"`);
-  }
-  if (post.section) {
-    lines.push(`section: "${post.section}"`);
-  }
-
-  lines.push('---', '', `# ${post.title}`, '', post.content);
-
-  return new Response(lines.join('\n'), {
-    headers: {
-      'Content-Type': 'text/markdown; charset=utf-8',
-      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
-    },
-  });
-}
-
-function createMockPost(overrides: Partial<PostData> = {}): PostData {
+function createMockPost(overrides: Partial<MarkdownPostData> = {}): MarkdownPostData {
   return {
     title: 'Test Post Title',
     slug: 'test-post-title',
@@ -66,16 +15,20 @@ function createMockPost(overrides: Partial<PostData> = {}): PostData {
   };
 }
 
+function buildWritingResponse(post: MarkdownPostData): Response {
+  return buildMarkdownResponse(post, 'writing', config.site.url);
+}
+
 describe('Writing Markdown Endpoint', () => {
   describe('response headers', () => {
     it('should return text/markdown content type', async () => {
-      const response = buildMarkdownResponse(createMockPost());
+      const response = buildWritingResponse(createMockPost());
 
       expect(response.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8');
     });
 
     it('should include cache-control headers', async () => {
-      const response = buildMarkdownResponse(createMockPost());
+      const response = buildWritingResponse(createMockPost());
 
       expect(response.headers.get('Cache-Control')).toBe(
         'public, max-age=3600, stale-while-revalidate=86400',
@@ -85,57 +38,54 @@ describe('Writing Markdown Endpoint', () => {
 
   describe('frontmatter', () => {
     it('should start and end with YAML delimiters', async () => {
-      const response = buildMarkdownResponse(createMockPost());
+      const response = buildWritingResponse(createMockPost());
       const body = await response.text();
 
       expect(body).toMatch(/^---\n/);
-      // Should have exactly two --- delimiters (start and end of frontmatter)
       const delimiterCount = (body.match(/^---$/gm) || []).length;
       expect(delimiterCount).toBe(2);
     });
 
     it('should include title, date, author, and canonical_url', async () => {
-      const response = buildMarkdownResponse(createMockPost());
+      const response = buildWritingResponse(createMockPost());
       const body = await response.text();
 
       expect(body).toContain('title: "Test Post Title"');
       expect(body).toContain('date: "2025-06-15"');
       expect(body).toContain('author: "Brennan Moore"');
-      expect(body).toContain(
-        'canonical_url: "https://www.zamiang.com/writing/test-post-title"',
-      );
+      expect(body).toContain('canonical_url: "https://www.zamiang.com/writing/test-post-title"');
     });
 
     it('should include excerpt when present', async () => {
-      const response = buildMarkdownResponse(createMockPost({ excerpt: 'A short summary' }));
+      const response = buildWritingResponse(createMockPost({ excerpt: 'A short summary' }));
       const body = await response.text();
 
       expect(body).toContain('excerpt: "A short summary"');
     });
 
     it('should omit excerpt when not present', async () => {
-      const response = buildMarkdownResponse(createMockPost({ excerpt: undefined }));
+      const response = buildWritingResponse(createMockPost({ excerpt: undefined }));
       const body = await response.text();
 
       expect(body).not.toContain('excerpt:');
     });
 
     it('should include section when present', async () => {
-      const response = buildMarkdownResponse(createMockPost({ section: 'VBC' }));
+      const response = buildWritingResponse(createMockPost({ section: 'VBC' }));
       const body = await response.text();
 
       expect(body).toContain('section: "VBC"');
     });
 
     it('should omit section when not present', async () => {
-      const response = buildMarkdownResponse(createMockPost({ section: undefined }));
+      const response = buildWritingResponse(createMockPost({ section: undefined }));
       const body = await response.text();
 
       expect(body).not.toContain('section:');
     });
 
     it('should escape double quotes in title', async () => {
-      const response = buildMarkdownResponse(
+      const response = buildWritingResponse(
         createMockPost({ title: 'Post with "Quotes" in Title' }),
       );
       const body = await response.text();
@@ -144,34 +94,47 @@ describe('Writing Markdown Endpoint', () => {
     });
 
     it('should escape double quotes in excerpt', async () => {
-      const response = buildMarkdownResponse(
+      const response = buildWritingResponse(
         createMockPost({ excerpt: 'An excerpt with "quotes"' }),
       );
       const body = await response.text();
 
       expect(body).toContain('excerpt: "An excerpt with \\"quotes\\""');
     });
+
+    it('should escape backslashes in title', async () => {
+      const response = buildWritingResponse(createMockPost({ title: 'The \\n (newline)' }));
+      const body = await response.text();
+
+      expect(body).toContain('title: "The \\\\n (newline)"');
+    });
+
+    it('should escape backslashes before quotes', async () => {
+      const response = buildWritingResponse(createMockPost({ title: 'path\\to\\"file"' }));
+      const body = await response.text();
+
+      expect(body).toContain('title: "path\\\\to\\\\\\"file\\""');
+    });
   });
 
   describe('body content', () => {
     it('should include the post title as an h1 heading after frontmatter', async () => {
-      const response = buildMarkdownResponse(createMockPost({ title: 'My Great Post' }));
+      const response = buildWritingResponse(createMockPost({ title: 'My Great Post' }));
       const body = await response.text();
 
       expect(body).toContain('\n# My Great Post\n');
     });
 
     it('should include the full markdown content', async () => {
-      const content =
-        '## Section One\n\nSome paragraph text.\n\n```js\nconsole.log("hello");\n```';
-      const response = buildMarkdownResponse(createMockPost({ content }));
+      const content = '## Section One\n\nSome paragraph text.\n\n```js\nconsole.log("hello");\n```';
+      const response = buildWritingResponse(createMockPost({ content }));
       const body = await response.text();
 
       expect(body).toContain(content);
     });
 
     it('should structure output as frontmatter → heading → content', async () => {
-      const response = buildMarkdownResponse(
+      const response = buildWritingResponse(
         createMockPost({
           title: 'Structured Post',
           content: 'Body content here.',
@@ -179,7 +142,6 @@ describe('Writing Markdown Endpoint', () => {
       );
       const body = await response.text();
 
-      // Split on frontmatter delimiters
       const parts = body.split('---');
       expect(parts).toHaveLength(3);
 
@@ -190,14 +152,14 @@ describe('Writing Markdown Endpoint', () => {
 
   describe('canonical URL', () => {
     it('should use /writing/ path prefix', async () => {
-      const response = buildMarkdownResponse(createMockPost({ slug: 'my-slug' }));
+      const response = buildWritingResponse(createMockPost({ slug: 'my-slug' }));
       const body = await response.text();
 
       expect(body).toContain('canonical_url: "https://www.zamiang.com/writing/my-slug"');
     });
 
     it('should use the configured site URL', async () => {
-      const response = buildMarkdownResponse(createMockPost());
+      const response = buildWritingResponse(createMockPost());
       const body = await response.text();
 
       expect(body).toContain(`canonical_url: "${config.site.url}/writing/`);

--- a/__tests__/pages/writing-markdown.test.ts
+++ b/__tests__/pages/writing-markdown.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+
+import { config } from '@/lib/config';
+
+/**
+ * Tests for the writing markdown endpoint.
+ *
+ * Since the endpoint uses astro:content (a virtual module), we can't import
+ * it directly in vitest. Instead, we extract and test the response-building
+ * logic directly, which is the core of the GET handler.
+ */
+
+interface PostData {
+  title: string;
+  slug: string;
+  date: string;
+  excerpt?: string;
+  content: string;
+  author: string;
+  section?: string;
+}
+
+/**
+ * Mirrors the GET handler logic from src/pages/writing/[slug].md.ts
+ * so we can test the markdown output without Astro's virtual modules.
+ */
+function buildMarkdownResponse(post: PostData): Response {
+  const siteUrl = config.site.url;
+  const canonicalUrl = `${siteUrl}/writing/${post.slug}`;
+
+  const lines = [
+    '---',
+    `title: "${post.title.replace(/"/g, '\\"')}"`,
+    `date: "${post.date}"`,
+    `author: "${post.author}"`,
+    `canonical_url: "${canonicalUrl}"`,
+  ];
+
+  if (post.excerpt) {
+    lines.push(`excerpt: "${post.excerpt.replace(/"/g, '\\"')}"`);
+  }
+  if (post.section) {
+    lines.push(`section: "${post.section}"`);
+  }
+
+  lines.push('---', '', `# ${post.title}`, '', post.content);
+
+  return new Response(lines.join('\n'), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+    },
+  });
+}
+
+function createMockPost(overrides: Partial<PostData> = {}): PostData {
+  return {
+    title: 'Test Post Title',
+    slug: 'test-post-title',
+    date: '2025-06-15',
+    author: 'Brennan Moore',
+    content: '## Hello World\n\nThis is a test post.',
+    excerpt: 'A test post excerpt',
+    section: undefined,
+    ...overrides,
+  };
+}
+
+describe('Writing Markdown Endpoint', () => {
+  describe('response headers', () => {
+    it('should return text/markdown content type', async () => {
+      const response = buildMarkdownResponse(createMockPost());
+
+      expect(response.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8');
+    });
+
+    it('should include cache-control headers', async () => {
+      const response = buildMarkdownResponse(createMockPost());
+
+      expect(response.headers.get('Cache-Control')).toBe(
+        'public, max-age=3600, stale-while-revalidate=86400',
+      );
+    });
+  });
+
+  describe('frontmatter', () => {
+    it('should start and end with YAML delimiters', async () => {
+      const response = buildMarkdownResponse(createMockPost());
+      const body = await response.text();
+
+      expect(body).toMatch(/^---\n/);
+      // Should have exactly two --- delimiters (start and end of frontmatter)
+      const delimiterCount = (body.match(/^---$/gm) || []).length;
+      expect(delimiterCount).toBe(2);
+    });
+
+    it('should include title, date, author, and canonical_url', async () => {
+      const response = buildMarkdownResponse(createMockPost());
+      const body = await response.text();
+
+      expect(body).toContain('title: "Test Post Title"');
+      expect(body).toContain('date: "2025-06-15"');
+      expect(body).toContain('author: "Brennan Moore"');
+      expect(body).toContain(
+        'canonical_url: "https://www.zamiang.com/writing/test-post-title"',
+      );
+    });
+
+    it('should include excerpt when present', async () => {
+      const response = buildMarkdownResponse(createMockPost({ excerpt: 'A short summary' }));
+      const body = await response.text();
+
+      expect(body).toContain('excerpt: "A short summary"');
+    });
+
+    it('should omit excerpt when not present', async () => {
+      const response = buildMarkdownResponse(createMockPost({ excerpt: undefined }));
+      const body = await response.text();
+
+      expect(body).not.toContain('excerpt:');
+    });
+
+    it('should include section when present', async () => {
+      const response = buildMarkdownResponse(createMockPost({ section: 'VBC' }));
+      const body = await response.text();
+
+      expect(body).toContain('section: "VBC"');
+    });
+
+    it('should omit section when not present', async () => {
+      const response = buildMarkdownResponse(createMockPost({ section: undefined }));
+      const body = await response.text();
+
+      expect(body).not.toContain('section:');
+    });
+
+    it('should escape double quotes in title', async () => {
+      const response = buildMarkdownResponse(
+        createMockPost({ title: 'Post with "Quotes" in Title' }),
+      );
+      const body = await response.text();
+
+      expect(body).toContain('title: "Post with \\"Quotes\\" in Title"');
+    });
+
+    it('should escape double quotes in excerpt', async () => {
+      const response = buildMarkdownResponse(
+        createMockPost({ excerpt: 'An excerpt with "quotes"' }),
+      );
+      const body = await response.text();
+
+      expect(body).toContain('excerpt: "An excerpt with \\"quotes\\""');
+    });
+  });
+
+  describe('body content', () => {
+    it('should include the post title as an h1 heading after frontmatter', async () => {
+      const response = buildMarkdownResponse(createMockPost({ title: 'My Great Post' }));
+      const body = await response.text();
+
+      expect(body).toContain('\n# My Great Post\n');
+    });
+
+    it('should include the full markdown content', async () => {
+      const content =
+        '## Section One\n\nSome paragraph text.\n\n```js\nconsole.log("hello");\n```';
+      const response = buildMarkdownResponse(createMockPost({ content }));
+      const body = await response.text();
+
+      expect(body).toContain(content);
+    });
+
+    it('should structure output as frontmatter → heading → content', async () => {
+      const response = buildMarkdownResponse(
+        createMockPost({
+          title: 'Structured Post',
+          content: 'Body content here.',
+        }),
+      );
+      const body = await response.text();
+
+      // Split on frontmatter delimiters
+      const parts = body.split('---');
+      expect(parts).toHaveLength(3);
+
+      const afterFrontmatter = parts[2];
+      expect(afterFrontmatter).toMatch(/\n\n# Structured Post\n\nBody content here\./);
+    });
+  });
+
+  describe('canonical URL', () => {
+    it('should use /writing/ path prefix', async () => {
+      const response = buildMarkdownResponse(createMockPost({ slug: 'my-slug' }));
+      const body = await response.text();
+
+      expect(body).toContain('canonical_url: "https://www.zamiang.com/writing/my-slug"');
+    });
+
+    it('should use the configured site URL', async () => {
+      const response = buildMarkdownResponse(createMockPost());
+      const body = await response.text();
+
+      expect(body).toContain(`canonical_url: "${config.site.url}/writing/`);
+    });
+  });
+});

--- a/public/_headers
+++ b/public/_headers
@@ -22,3 +22,10 @@
 /feed.json
   Content-Type: application/feed+json; charset=utf-8
   Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+
+# Markdown alternate endpoints
+/writing/*.md
+  Content-Type: text/markdown; charset=utf-8
+
+/photos/*.md
+  Content-Type: text/markdown; charset=utf-8

--- a/public/_headers
+++ b/public/_headers
@@ -26,6 +26,8 @@
 # Markdown alternate endpoints
 /writing/*.md
   Content-Type: text/markdown; charset=utf-8
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
 
 /photos/*.md
   Content-Type: text/markdown; charset=utf-8
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -104,6 +104,15 @@ const VBC_TITLE = 'Why Value-Based Care is Harder Than Rocket Science';
   article={true}
   canonicalUrl={`${siteUrl}/${type}/${post.slug}`}
 >
+  <Fragment slot="head">
+    <link
+      href={`${siteUrl}/${type}/${post.slug}.md`}
+      type="text/markdown"
+      rel="alternate"
+      title="Markdown"
+    />
+  </Fragment>
+
   <Fragment slot="json-ld">
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   </Fragment>

--- a/src/lib/markdown-response.ts
+++ b/src/lib/markdown-response.ts
@@ -44,6 +44,14 @@ export function toMarkdownPostData(raw: Record<string, unknown>): MarkdownPostDa
 }
 
 /**
+ * Escapes markdown formatting characters so text renders literally.
+ * Used for the H1 title in the body to prevent unintended bold/italic/etc.
+ */
+function escapeMarkdown(value: string): string {
+  return value.replace(/([*_`~\[\]#|\\>])/g, '\\$1');
+}
+
+/**
  * Builds a markdown Response with YAML frontmatter for a given post.
  *
  * @param post - The post data to render as markdown
@@ -57,12 +65,14 @@ export function buildMarkdownResponse(
 ): Response {
   const canonicalUrl = `${siteUrl}/${type}/${post.slug}`;
 
+  // All string values are escaped for YAML double-quoted scalars,
+  // even date and canonical_url, for consistency.
   const lines = [
     '---',
     `title: "${escapeYamlString(post.title)}"`,
-    `date: "${post.date}"`,
+    `date: "${escapeYamlString(post.date)}"`,
     `author: "${escapeYamlString(post.author)}"`,
-    `canonical_url: "${canonicalUrl}"`,
+    `canonical_url: "${escapeYamlString(canonicalUrl)}"`,
   ];
 
   if (post.excerpt) {
@@ -72,8 +82,11 @@ export function buildMarkdownResponse(
     lines.push(`section: "${escapeYamlString(post.section)}"`);
   }
 
-  lines.push('---', '', `# ${post.title}`, '', post.content);
+  lines.push('---', '', `# ${escapeMarkdown(post.title)}`, '', post.content);
 
+  // Headers are set here for `astro preview` (local dev). In production,
+  // Cloudflare Pages serves these as static files and public/_headers
+  // is the authoritative source for Content-Type and Cache-Control.
   return new Response(lines.join('\n'), {
     headers: {
       'Content-Type': 'text/markdown; charset=utf-8',

--- a/src/lib/markdown-response.ts
+++ b/src/lib/markdown-response.ts
@@ -16,10 +16,31 @@ export interface MarkdownPostData {
 
 /**
  * Escapes a string for use in a YAML double-quoted scalar.
- * Handles backslashes (must be first) and double quotes.
+ * Handles backslashes (must be first), then double quotes and control characters.
  */
-function escapeYamlString(value: string): string {
-  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+export function escapeYamlString(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+}
+
+/**
+ * Safely maps raw post data to MarkdownPostData, providing defaults
+ * for missing fields instead of silently passing through nulls.
+ */
+export function toMarkdownPostData(raw: Record<string, unknown>): MarkdownPostData {
+  return {
+    title: String(raw.title ?? 'Untitled'),
+    slug: String(raw.slug ?? ''),
+    date: String(raw.date ?? ''),
+    author: String(raw.author ?? ''),
+    content: String(raw.content ?? ''),
+    excerpt: raw.excerpt ? String(raw.excerpt) : undefined,
+    section: raw.section ? String(raw.section) : undefined,
+  };
 }
 
 /**

--- a/src/lib/markdown-response.ts
+++ b/src/lib/markdown-response.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared utility for building markdown responses from post data.
+ * Used by the /writing/[slug].md and /photos/[slug].md endpoints.
+ * Extracted here so vitest can test the real logic without astro:content.
+ */
+
+export interface MarkdownPostData {
+  title: string;
+  slug: string;
+  date: string;
+  excerpt?: string;
+  content: string;
+  author: string;
+  section?: string;
+}
+
+/**
+ * Escapes a string for use in a YAML double-quoted scalar.
+ * Handles backslashes (must be first) and double quotes.
+ */
+function escapeYamlString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
+ * Builds a markdown Response with YAML frontmatter for a given post.
+ *
+ * @param post - The post data to render as markdown
+ * @param type - The content type path prefix ('writing' or 'photos')
+ * @param siteUrl - The base site URL for canonical links
+ */
+export function buildMarkdownResponse(
+  post: MarkdownPostData,
+  type: 'writing' | 'photos',
+  siteUrl: string,
+): Response {
+  const canonicalUrl = `${siteUrl}/${type}/${post.slug}`;
+
+  const lines = [
+    '---',
+    `title: "${escapeYamlString(post.title)}"`,
+    `date: "${post.date}"`,
+    `author: "${escapeYamlString(post.author)}"`,
+    `canonical_url: "${canonicalUrl}"`,
+  ];
+
+  if (post.excerpt) {
+    lines.push(`excerpt: "${escapeYamlString(post.excerpt)}"`);
+  }
+  if (post.section) {
+    lines.push(`section: "${escapeYamlString(post.section)}"`);
+  }
+
+  lines.push('---', '', `# ${post.title}`, '', post.content);
+
+  return new Response(lines.join('\n'), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+    },
+  });
+}

--- a/src/pages/photos/[slug].md.ts
+++ b/src/pages/photos/[slug].md.ts
@@ -1,0 +1,54 @@
+/**
+ * Markdown endpoint for individual photo posts
+ * Serves raw markdown content for AI agents and tools
+ */
+import type { APIContext } from 'astro';
+import { getCollection } from 'astro:content';
+
+import { config } from '../../lib/config';
+
+export async function getStaticPaths() {
+  const photos = await getCollection('photos');
+
+  return photos.map((photo) => ({
+    params: { slug: photo.data.slug },
+    props: { post: photo.data },
+  }));
+}
+
+export async function GET(context: APIContext) {
+  const post = context.props.post as {
+    title: string;
+    slug: string;
+    date: string;
+    excerpt?: string;
+    content: string;
+    author: string;
+    coverImage: string;
+  };
+
+  const siteUrl = config.site.url;
+  const canonicalUrl = `${siteUrl}/photos/${post.slug}`;
+
+  // Build markdown with frontmatter
+  const lines = [
+    '---',
+    `title: "${post.title.replace(/"/g, '\\"')}"`,
+    `date: "${post.date}"`,
+    `author: "${post.author}"`,
+    `canonical_url: "${canonicalUrl}"`,
+  ];
+
+  if (post.excerpt) {
+    lines.push(`excerpt: "${post.excerpt.replace(/"/g, '\\"')}"`);
+  }
+
+  lines.push('---', '', `# ${post.title}`, '', post.content);
+
+  return new Response(lines.join('\n'), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+    },
+  });
+}

--- a/src/pages/photos/[slug].md.ts
+++ b/src/pages/photos/[slug].md.ts
@@ -6,7 +6,7 @@ import type { APIContext } from 'astro';
 import { getCollection } from 'astro:content';
 
 import { config } from '../../lib/config';
-import { type MarkdownPostData, buildMarkdownResponse } from '../../lib/markdown-response';
+import { buildMarkdownResponse, toMarkdownPostData } from '../../lib/markdown-response';
 
 export async function getStaticPaths() {
   const photos = await getCollection('photos');
@@ -18,6 +18,6 @@ export async function getStaticPaths() {
 }
 
 export async function GET(context: APIContext) {
-  const post = context.props.post as MarkdownPostData;
+  const post = toMarkdownPostData(context.props.post as Record<string, unknown>);
   return buildMarkdownResponse(post, 'photos', config.site.url);
 }

--- a/src/pages/photos/[slug].md.ts
+++ b/src/pages/photos/[slug].md.ts
@@ -6,6 +6,7 @@ import type { APIContext } from 'astro';
 import { getCollection } from 'astro:content';
 
 import { config } from '../../lib/config';
+import { type MarkdownPostData, buildMarkdownResponse } from '../../lib/markdown-response';
 
 export async function getStaticPaths() {
   const photos = await getCollection('photos');
@@ -17,38 +18,6 @@ export async function getStaticPaths() {
 }
 
 export async function GET(context: APIContext) {
-  const post = context.props.post as {
-    title: string;
-    slug: string;
-    date: string;
-    excerpt?: string;
-    content: string;
-    author: string;
-    coverImage: string;
-  };
-
-  const siteUrl = config.site.url;
-  const canonicalUrl = `${siteUrl}/photos/${post.slug}`;
-
-  // Build markdown with frontmatter
-  const lines = [
-    '---',
-    `title: "${post.title.replace(/"/g, '\\"')}"`,
-    `date: "${post.date}"`,
-    `author: "${post.author}"`,
-    `canonical_url: "${canonicalUrl}"`,
-  ];
-
-  if (post.excerpt) {
-    lines.push(`excerpt: "${post.excerpt.replace(/"/g, '\\"')}"`);
-  }
-
-  lines.push('---', '', `# ${post.title}`, '', post.content);
-
-  return new Response(lines.join('\n'), {
-    headers: {
-      'Content-Type': 'text/markdown; charset=utf-8',
-      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
-    },
-  });
+  const post = context.props.post as MarkdownPostData;
+  return buildMarkdownResponse(post, 'photos', config.site.url);
 }

--- a/src/pages/writing/[slug].md.ts
+++ b/src/pages/writing/[slug].md.ts
@@ -6,20 +6,28 @@ import type { APIContext } from 'astro';
 import { getCollection } from 'astro:content';
 
 import { config } from '../../lib/config';
-import { type MarkdownPostData, buildMarkdownResponse } from '../../lib/markdown-response';
+import { buildMarkdownResponse, toMarkdownPostData } from '../../lib/markdown-response';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
   const vbcPosts = await getCollection('vbcPosts');
-  const allPosts = [...posts, ...vbcPosts];
 
-  return allPosts.map((post) => ({
+  // Deduplicate by slug — if both collections contain the same slug,
+  // the first entry wins (matches posts before vbcPosts).
+  const seen = new Map<string, (typeof posts)[number]>();
+  for (const post of [...posts, ...vbcPosts]) {
+    if (!seen.has(post.data.slug)) {
+      seen.set(post.data.slug, post);
+    }
+  }
+
+  return Array.from(seen.values()).map((post) => ({
     params: { slug: post.data.slug },
     props: { post: post.data },
   }));
 }
 
 export async function GET(context: APIContext) {
-  const post = context.props.post as MarkdownPostData;
+  const post = toMarkdownPostData(context.props.post as Record<string, unknown>);
   return buildMarkdownResponse(post, 'writing', config.site.url);
 }

--- a/src/pages/writing/[slug].md.ts
+++ b/src/pages/writing/[slug].md.ts
@@ -1,0 +1,59 @@
+/**
+ * Markdown endpoint for individual writing posts
+ * Serves raw markdown content for AI agents and tools
+ */
+import type { APIContext } from 'astro';
+import { getCollection } from 'astro:content';
+
+import { config } from '../../lib/config';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('posts');
+  const vbcPosts = await getCollection('vbcPosts');
+  const allPosts = [...posts, ...vbcPosts];
+
+  return allPosts.map((post) => ({
+    params: { slug: post.data.slug },
+    props: { post: post.data },
+  }));
+}
+
+export async function GET(context: APIContext) {
+  const post = context.props.post as {
+    title: string;
+    slug: string;
+    date: string;
+    excerpt?: string;
+    content: string;
+    author: string;
+    section?: string;
+  };
+
+  const siteUrl = config.site.url;
+  const canonicalUrl = `${siteUrl}/writing/${post.slug}`;
+
+  // Build markdown with frontmatter
+  const lines = [
+    '---',
+    `title: "${post.title.replace(/"/g, '\\"')}"`,
+    `date: "${post.date}"`,
+    `author: "${post.author}"`,
+    `canonical_url: "${canonicalUrl}"`,
+  ];
+
+  if (post.excerpt) {
+    lines.push(`excerpt: "${post.excerpt.replace(/"/g, '\\"')}"`);
+  }
+  if (post.section) {
+    lines.push(`section: "${post.section}"`);
+  }
+
+  lines.push('---', '', `# ${post.title}`, '', post.content);
+
+  return new Response(lines.join('\n'), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+    },
+  });
+}

--- a/src/pages/writing/[slug].md.ts
+++ b/src/pages/writing/[slug].md.ts
@@ -6,6 +6,7 @@ import type { APIContext } from 'astro';
 import { getCollection } from 'astro:content';
 
 import { config } from '../../lib/config';
+import { type MarkdownPostData, buildMarkdownResponse } from '../../lib/markdown-response';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
@@ -19,41 +20,6 @@ export async function getStaticPaths() {
 }
 
 export async function GET(context: APIContext) {
-  const post = context.props.post as {
-    title: string;
-    slug: string;
-    date: string;
-    excerpt?: string;
-    content: string;
-    author: string;
-    section?: string;
-  };
-
-  const siteUrl = config.site.url;
-  const canonicalUrl = `${siteUrl}/writing/${post.slug}`;
-
-  // Build markdown with frontmatter
-  const lines = [
-    '---',
-    `title: "${post.title.replace(/"/g, '\\"')}"`,
-    `date: "${post.date}"`,
-    `author: "${post.author}"`,
-    `canonical_url: "${canonicalUrl}"`,
-  ];
-
-  if (post.excerpt) {
-    lines.push(`excerpt: "${post.excerpt.replace(/"/g, '\\"')}"`);
-  }
-  if (post.section) {
-    lines.push(`section: "${post.section}"`);
-  }
-
-  lines.push('---', '', `# ${post.title}`, '', post.content);
-
-  return new Response(lines.join('\n'), {
-    headers: {
-      'Content-Type': 'text/markdown; charset=utf-8',
-      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
-    },
-  });
+  const post = context.props.post as MarkdownPostData;
+  return buildMarkdownResponse(post, 'writing', config.site.url);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -18,18 +14,11 @@
     "jsx": "react-jsx",
     "incremental": true,
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     },
-    "types": [
-      "vitest/globals"
-    ]
+    "types": ["vitest/globals"]
   },
-  "include": [
-    "**/*.ts",
-    "**/*.tsx"
-  ],
+  "include": ["**/*.ts", "**/*.tsx"],
   "exclude": [
     "node_modules",
     ".astro",
@@ -37,6 +26,8 @@
     "src/content/config.ts",
     "src/lib/notion-loader.ts",
     "src/pages/feed.json.ts",
-    "src/pages/rss.xml.ts"
+    "src/pages/rss.xml.ts",
+    "src/pages/writing/[slug].md.ts",
+    "src/pages/photos/[slug].md.ts"
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `/writing/[slug].md` and `/photos/[slug].md` static endpoints that serve raw markdown with YAML frontmatter (title, date, author, canonical_url, excerpt, section)
- Adds `<link rel="alternate" type="text/markdown">` tag to the `<head>` of every post/photo page for discoverability by AI agents and tools
- Includes 26 new tests covering response headers, frontmatter generation, quote escaping, optional field handling, and content structure

## Test plan

- [x] All 176 tests pass (150 existing + 26 new)
- [x] TypeScript compiles cleanly
- [x] Astro build picks up new routes (verified in build output)
- [ ] Verify `.md` URLs resolve correctly in deployed preview
- [ ] Confirm `<link>` tag appears in post page `<head>` source

🤖 Generated with [Claude Code](https://claude.com/claude-code)