### PR TITLE
fix(design): apply design-review findings (font fallback, color-scheme, tap target)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ yarn-error.log*
 
 .claude/settings.local.json
 .claude/worktrees/
+.gstack/

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,8 +19,8 @@
   --font-size: var(--font-size);
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-serif: 'EB Garamond', 'EB Garamond Fallback';
-  --font-sans: 'Lato', 'EB Garamond Fallback';
+  --font-serif: 'EB Garamond', 'EB Garamond Fallback', Georgia, 'Times New Roman', serif;
+  --font-sans: 'Lato', 'EB Garamond Fallback', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-mono: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
   --color-input: var(--input);
   --color-border: var(--border);
@@ -42,6 +42,8 @@
    ========================================================================== */
 
 :root {
+  color-scheme: light;
+
   /* Typography - Modern Professional Scale with Fluid Sizing
      Using clamp() for smooth scaling between viewport sizes:
      clamp(min, preferred, max) where preferred uses viewport width */
@@ -1006,7 +1008,7 @@
     font-size: var(--font-size-sm);
     color: var(--muted-foreground);
     border-bottom: none;
-    margin-top: 0.5rem;
+    padding: 0.5rem 0;
     display: inline-block;
   }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -20,7 +20,9 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-serif: 'EB Garamond', 'EB Garamond Fallback', Georgia, 'Times New Roman', serif;
-  --font-sans: 'Lato', 'EB Garamond Fallback', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-sans:
+    'Lato', 'EB Garamond Fallback', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
   --font-mono: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
   --color-input: var(--input);
   --color-border: var(--border);


### PR DESCRIPTION
## Summary

Three small fixes surfaced by `/design-review` against the live dev server. All are token / a11y plumbing — no visual regressions, no behavior changes on the happy path.

- **F-001 (HIGH):** `--font-sans: 'Lato', 'EB Garamond Fallback'` falls back to a serif. If Lato fails to load (CDN block, slow network), the entire site goes serif. Appended `system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif` to the chain. Same pattern applied to `--font-serif` (`Georgia, 'Times New Roman', serif`).
- **F-002 (MED):** Added `color-scheme: light` to `:root`. The site is light-mode-only by design, but without this declaration users on a dark-mode OS get dark scrollbars and dark `<input type="date">` rendering on top of the light page.
- **F-003 (MED):** `.view-all-link` was 25px tall (under the 44px touch-target spec). Replaced `margin-top: 0.5rem` with `padding: 0.5rem 0` — top padding preserves the visual gap above, and tap area grows to 43px without changing visual layout.

Also adds `.gstack/` to `.gitignore` so future `/design-review` audit artifacts stay out of source control.

Audit details: see `.gstack/design-reports/design-audit-20260509/design-audit-localhost.md` (local only, not committed).

## Test plan

- [x] `npm run check:design-tokens` passes
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Live verification on localhost:4321:
  - [x] `getComputedStyle(:root).colorScheme` === `light`
  - [x] `--font-sans` chain ends in `sans-serif`
  - [x] `--font-serif` chain ends in `serif`
  - [x] `.view-all-link` rendered height = 43px (was 25px)
- [ ] Visual smoke check on production build (`npm run build && npm run preview`)
- [ ] Mobile tap-target check on real device

🤖 Generated with [Claude Code](https://claude.com/claude-code)