### PR TITLE
Redesign post header — eyebrow, italic subtitle, monospace meta strip

### DIFF
--- a/src/components/islands/ContentRenderer.tsx
+++ b/src/components/islands/ContentRenderer.tsx
@@ -27,19 +27,6 @@ function getTextContent(children: ReactNode): string {
   return '';
 }
 
-// Decorative coordinate string — deterministic from caption text.
-// Values stay inside a plausible North America bounding box; this is
-// purely visual flavour, the values aren't meaningful.
-function fauxCoords(seed: string): string {
-  let hash = 0;
-  for (let i = 0; i < seed.length; i++) {
-    hash = (hash * 31 + seed.charCodeAt(i)) >>> 0;
-  }
-  const lat = 24 + (hash % 2500) / 100; // 24.00 – 49.00 N
-  const lon = 66 + ((hash >>> 8) % 5900) / 100; // 66.00 – 125.00 W
-  return `N ${lat.toFixed(2)} · W ${lon.toFixed(2)}`;
-}
-
 const baseComponents = {
   p: ({ children }: { children?: React.ReactNode }) => <p>{children}</p>,
   a: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
@@ -118,50 +105,15 @@ const baseComponents = {
   ),
 };
 
-const galleryFigcaption = ({ children }: { children?: React.ReactNode }) => {
-  const text = getTextContent(children);
-  return (
-    <figcaption className="photos-cap">
-      {text ? <span className="cap-title">{children}</span> : <span className="cap-title" />}
-      <span className="cap-coords" aria-hidden="true">
-        {fauxCoords(text || 'frame')}
-      </span>
-    </figcaption>
-  );
-};
-
-// In gallery mode, wrap figures so figures without a markdown caption still
-// get the decorative right-side coords. The figcaption itself is added as a
-// sibling and styled by .photos-cap.
-const galleryFigure = ({ children }: { children?: React.ReactNode }) => {
-  const childArray = React.Children.toArray(children);
-  const hasCaption = childArray.some(
-    (c) => isValidElement(c) && (c as React.ReactElement).type === 'figcaption',
-  );
-
-  if (hasCaption) return <figure>{children}</figure>;
-
-  // Derive a stable seed from any img src/alt found inside.
-  const img = childArray.find((c) => isValidElement(c) && (c as React.ReactElement).type === 'img');
-  const props = (isValidElement(img) ? (img.props as { src?: string; alt?: string }) : {}) || {};
-  const seed = props.alt || props.src || 'frame';
-
-  return (
-    <figure>
-      {children}
-      <figcaption className="photos-cap">
-        <span className="cap-title" />
-        <span className="cap-coords" aria-hidden="true">
-          {fauxCoords(seed)}
-        </span>
-      </figcaption>
-    </figure>
-  );
-};
+const galleryFigcaption = ({ children }: { children?: React.ReactNode }) => (
+  <figcaption className="photos-cap">
+    <span className="cap-title">{children}</span>
+  </figcaption>
+);
 
 export default function ContentRenderer({ content, gallery = false }: ContentRendererProps) {
   const components = gallery
-    ? { ...baseComponents, figure: galleryFigure, figcaption: galleryFigcaption }
+    ? { ...baseComponents, figcaption: galleryFigcaption }
     : baseComponents;
 
   return (

--- a/src/components/islands/ContentRenderer.tsx
+++ b/src/components/islands/ContentRenderer.tsx
@@ -122,17 +122,46 @@ const galleryFigcaption = ({ children }: { children?: React.ReactNode }) => {
   const text = getTextContent(children);
   return (
     <figcaption className="photos-cap">
-      <span className="cap-title">{children}</span>
+      {text ? <span className="cap-title">{children}</span> : <span className="cap-title" />}
       <span className="cap-coords" aria-hidden="true">
-        {fauxCoords(text)}
+        {fauxCoords(text || 'frame')}
       </span>
     </figcaption>
   );
 };
 
+// In gallery mode, wrap figures so figures without a markdown caption still
+// get the decorative right-side coords. The figcaption itself is added as a
+// sibling and styled by .photos-cap.
+const galleryFigure = ({ children }: { children?: React.ReactNode }) => {
+  const childArray = React.Children.toArray(children);
+  const hasCaption = childArray.some(
+    (c) => isValidElement(c) && (c as React.ReactElement).type === 'figcaption',
+  );
+
+  if (hasCaption) return <figure>{children}</figure>;
+
+  // Derive a stable seed from any img src/alt found inside.
+  const img = childArray.find((c) => isValidElement(c) && (c as React.ReactElement).type === 'img');
+  const props = (isValidElement(img) ? (img.props as { src?: string; alt?: string }) : {}) || {};
+  const seed = props.alt || props.src || 'frame';
+
+  return (
+    <figure>
+      {children}
+      <figcaption className="photos-cap">
+        <span className="cap-title" />
+        <span className="cap-coords" aria-hidden="true">
+          {fauxCoords(seed)}
+        </span>
+      </figcaption>
+    </figure>
+  );
+};
+
 export default function ContentRenderer({ content, gallery = false }: ContentRendererProps) {
   const components = gallery
-    ? { ...baseComponents, figcaption: galleryFigcaption }
+    ? { ...baseComponents, figure: galleryFigure, figcaption: galleryFigcaption }
     : baseComponents;
 
   return (

--- a/src/components/islands/ContentRenderer.tsx
+++ b/src/components/islands/ContentRenderer.tsx
@@ -14,6 +14,7 @@ import { cn } from '../../lib/utils';
 
 interface ContentRendererProps {
   content: string;
+  gallery?: boolean;
 }
 
 function getTextContent(children: ReactNode): string {
@@ -26,7 +27,20 @@ function getTextContent(children: ReactNode): string {
   return '';
 }
 
-const components = {
+// Decorative coordinate string — deterministic from caption text.
+// Values stay inside a plausible North America bounding box; this is
+// purely visual flavour, the values aren't meaningful.
+function fauxCoords(seed: string): string {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) >>> 0;
+  }
+  const lat = 24 + (hash % 2500) / 100; // 24.00 – 49.00 N
+  const lon = 66 + ((hash >>> 8) % 5900) / 100; // 66.00 – 125.00 W
+  return `N ${lat.toFixed(2)} · W ${lon.toFixed(2)}`;
+}
+
+const baseComponents = {
   p: ({ children }: { children?: React.ReactNode }) => <p>{children}</p>,
   a: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
     <a href={href}>{children}</a>
@@ -104,7 +118,23 @@ const components = {
   ),
 };
 
-export default function ContentRenderer({ content }: ContentRendererProps) {
+const galleryFigcaption = ({ children }: { children?: React.ReactNode }) => {
+  const text = getTextContent(children);
+  return (
+    <figcaption className="photos-cap">
+      <span className="cap-title">{children}</span>
+      <span className="cap-coords" aria-hidden="true">
+        {fauxCoords(text)}
+      </span>
+    </figcaption>
+  );
+};
+
+export default function ContentRenderer({ content, gallery = false }: ContentRendererProps) {
+  const components = gallery
+    ? { ...baseComponents, figcaption: galleryFigcaption }
+    : baseComponents;
+
   return (
     <div className="prose prose-slate max-w-none mb-12 prose-headings:font-serif prose-headings:font-medium prose-headings:text-foreground prose-p:text-foreground/90 prose-a:text-accent prose-a:no-underline hover:prose-a:text-accent/80 prose-strong:text-foreground prose-strong:font-semibold prose-blockquote:border-accent prose-blockquote:text-muted-foreground">
       <ReactMarkdown

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -48,10 +48,7 @@ function sectionNumber(slug: string): string {
 const eyebrowLabel =
   type === 'photos' ? 'Photography' : post.section === 'VBC' ? 'VBC Series' : 'Essay';
 const eyebrowNumber = sectionNumber(post.slug);
-const datePublishedLabel = postDate
-  .toISOString()
-  .split('T')[0]
-  .replace(/-/g, '.');
+const datePublishedLabel = postDate.toISOString().split('T')[0].replace(/-/g, '.');
 const lastUpdatedLabel = (post.dateModified ? new Date(post.dateModified) : postDate)
   .toISOString()
   .split('T')[0]

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -168,7 +168,7 @@ const VBC_TITLE = 'Why Value-Based Care is Harder Than Rocket Science';
         <span>{eyebrowLabel}</span>
         <span class="sep" aria-hidden="true">&middot;</span>
         <span>
-          <time datetime={postDate.toISOString().split('T')[0]}>{datePublishedLabel}</time>
+          <time datetime={post.date.split('T')[0]}>{datePublishedLabel}</time>
         </span>
         {
           type === 'writing' && (

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -48,11 +48,12 @@ function sectionNumber(slug: string): string {
 const eyebrowLabel =
   type === 'photos' ? 'Photography' : post.section === 'VBC' ? 'VBC Series' : 'Essay';
 const eyebrowNumber = sectionNumber(post.slug);
-const datePublishedLabel = postDate.toISOString().split('T')[0].replace(/-/g, '.');
-const lastUpdatedLabel = (post.dateModified ? new Date(post.dateModified) : postDate)
-  .toISOString()
-  .split('T')[0]
-  .replace(/-/g, '.');
+// Format the raw ISO date string directly to avoid a Date round-trip that
+// could shift the displayed day across timezones. `post.date` is the source
+// of truth — strip any time component and swap separators.
+const formatIsoDate = (iso: string) => iso.split('T')[0].replace(/-/g, '.');
+const datePublishedLabel = formatIsoDate(post.date);
+const lastUpdatedLabel = formatIsoDate(post.dateModified ?? post.date);
 
 // Calculate reading time
 const wordCount = post.content

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -4,8 +4,6 @@
  * Includes header, TOC, content, and footer sections
  */
 
-import { format } from 'date-fns';
-
 import ContentRenderer from '../components/islands/ContentRenderer';
 import type { TocItem } from '../components/TableOfContents.astro';
 import TableOfContents from '../components/TableOfContents.astro';
@@ -37,6 +35,27 @@ const { post, type = 'writing' } = Astro.props;
 
 const postDate = new Date(post.date);
 const siteUrl = config.site.url;
+
+// Decorative section number derived deterministically from the slug.
+function sectionNumber(slug: string): string {
+  let hash = 0;
+  for (let i = 0; i < slug.length; i++) {
+    hash = (hash * 31 + slug.charCodeAt(i)) >>> 0;
+  }
+  return String((hash % 99) + 1).padStart(2, '0');
+}
+
+const eyebrowLabel =
+  type === 'photos' ? 'Photography' : post.section === 'VBC' ? 'VBC Series' : 'Essay';
+const eyebrowNumber = sectionNumber(post.slug);
+const datePublishedLabel = postDate
+  .toISOString()
+  .split('T')[0]
+  .replace(/-/g, '.');
+const lastUpdatedLabel = (post.dateModified ? new Date(post.dateModified) : postDate)
+  .toISOString()
+  .split('T')[0]
+  .replace(/-/g, '.');
 
 // Calculate reading time
 const wordCount = post.content
@@ -118,56 +137,50 @@ const VBC_TITLE = 'Why Value-Based Care is Harder Than Rocket Science';
   </Fragment>
 
   <article class="max-w-2xl mx-auto">
-    <header class="mb-8">
-      {/* VBC Badge */}
+    <header class="post-header">
+      {/* Eyebrow: § NN · CATEGORY */}
+      <div class="post-eyebrow" aria-label={`Section ${eyebrowNumber}, ${eyebrowLabel}`}>
+        <span class="post-eyebrow-mark" aria-hidden="true">&sect;</span>
+        <span class="post-eyebrow-num">{eyebrowNumber}</span>
+        <span class="post-eyebrow-sep" aria-hidden="true">&middot;</span>
+        <span class="post-eyebrow-label">{eyebrowLabel}</span>
+      </div>
+
+      {/* Optional VBC series tie-in — quieter than the old pill */}
       {
         post.section === 'VBC' && (
-          <div class="mb-4">
-            <a
-              href="/#vbc"
-              class="inline-block text-xs font-semibold uppercase tracking-wider text-accent bg-accent/15 px-3 py-1 rounded hover:bg-accent/25 transition-colors duration-150 !border-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
-            >
-              {VBC_TITLE}
-            </a>
-          </div>
+          <a href="/#vbc" class="post-series-link">
+            From the series: <em>{VBC_TITLE}</em>
+          </a>
         )
       }
 
-      {/* Date and reading time */}
-      <div class="section-label flex items-center gap-2 mb-3">
-        <time datetime={postDate.toISOString().split('T')[0]}>
-          {format(postDate, 'MMMM d, yyyy')}
-        </time>
+      {/* Title */}
+      <h1 class="post-title">{post.title}</h1>
+
+      {/* Subtitle — italic serif, like the screenshot */}
+      {post.excerpt && <p class="post-subtitle">{post.excerpt}</p>}
+
+      {/* Meta strip — monospace, hairline-bracketed */}
+      <div class="post-meta-strip" role="group" aria-label="Post details">
+        <span>{eyebrowLabel}</span>
+        <span class="sep" aria-hidden="true">&middot;</span>
+        <span>
+          <time datetime={postDate.toISOString().split('T')[0]}>{datePublishedLabel}</time>
+        </span>
         {
           type === 'writing' && (
             <>
-              <span class="text-border" aria-hidden="true">
-                ·
+              <span class="sep" aria-hidden="true">
+                &middot;
               </span>
-              <span>{readingTime}</span>
+              <span>{readingTime.toUpperCase()}</span>
             </>
           )
         }
+        <span class="sep" aria-hidden="true">&middot;</span>
+        <span>Last updated {lastUpdatedLabel}</span>
       </div>
-
-      {/* Title */}
-      <h1
-        class="font-serif font-medium leading-tight mb-4 text-foreground"
-        style="font-size: var(--font-size-4xl)"
-      >
-        {post.title}
-      </h1>
-
-      {/* Excerpt */}
-      {
-        post.excerpt && (
-          <p class="section-subtitle" style="font-size: var(--font-size-lg)">
-            {post.excerpt}
-          </p>
-        )
-      }
-
-      <div class="section-rule mt-6" aria-hidden="true"></div>
     </header>
 
     {/* Table of Contents */}

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -50,10 +50,14 @@ const eyebrowLabel =
 const eyebrowNumber = sectionNumber(post.slug);
 // Format the raw ISO date string directly to avoid a Date round-trip that
 // could shift the displayed day across timezones. `post.date` is the source
-// of truth — strip any time component and swap separators.
-const formatIsoDate = (iso: string) => iso.split('T')[0].replace(/-/g, '.');
+// of truth — strip any time component and swap separators. Notion loader
+// guarantees a non-empty YYYY-MM-DD; an empty input yields an empty string.
+const formatIsoDate = (iso: string | undefined) =>
+  iso ? iso.split('T')[0].replace(/-/g, '.') : '';
 const datePublishedLabel = formatIsoDate(post.date);
-const lastUpdatedLabel = formatIsoDate(post.dateModified ?? post.date);
+const hasMeaningfulModified =
+  !!post.dateModified && post.dateModified.split('T')[0] !== post.date.split('T')[0];
+const lastUpdatedLabel = hasMeaningfulModified ? formatIsoDate(post.dateModified) : '';
 
 // Calculate reading time
 const wordCount = post.content
@@ -137,11 +141,11 @@ const VBC_TITLE = 'Why Value-Based Care is Harder Than Rocket Science';
   <article class:list={['post-article', { 'post-article--photos': type === 'photos' }]}>
     <header class="post-header">
       {/* Eyebrow: § NN · CATEGORY */}
-      <div class="post-eyebrow" aria-label={`Section ${eyebrowNumber}, ${eyebrowLabel}`}>
-        <span class="post-eyebrow-mark" aria-hidden="true">&sect;</span>
-        <span class="post-eyebrow-num">{eyebrowNumber}</span>
-        <span class="post-eyebrow-sep" aria-hidden="true">&middot;</span>
-        <span class="post-eyebrow-label">{eyebrowLabel}</span>
+      <div class="bm-eyebrow" aria-label={`Section ${eyebrowNumber}, ${eyebrowLabel}`}>
+        <span class="bm-eyebrow-mark" aria-hidden="true">&sect;</span>
+        <span class="bm-eyebrow-num">{eyebrowNumber}</span>
+        <span class="bm-eyebrow-sep" aria-hidden="true">&middot;</span>
+        <span class="bm-eyebrow-label">{eyebrowLabel}</span>
       </div>
 
       {/* Optional VBC series tie-in — quieter than the old pill */}
@@ -176,8 +180,16 @@ const VBC_TITLE = 'Why Value-Based Care is Harder Than Rocket Science';
             </>
           )
         }
-        <span class="sep" aria-hidden="true">&middot;</span>
-        <span>Last updated {lastUpdatedLabel}</span>
+        {
+          hasMeaningfulModified && (
+            <>
+              <span class="sep" aria-hidden="true">
+                &middot;
+              </span>
+              <span>Last updated {lastUpdatedLabel}</span>
+            </>
+          )
+        }
       </div>
     </header>
 

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -134,7 +134,7 @@ const VBC_TITLE = 'Why Value-Based Care is Harder Than Rocket Science';
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   </Fragment>
 
-  <article class="max-w-2xl mx-auto">
+  <article class:list={['post-article', { 'post-article--photos': type === 'photos' }]}>
     <header class="post-header">
       {/* Eyebrow: § NN · CATEGORY */}
       <div class="post-eyebrow" aria-label={`Section ${eyebrowNumber}, ${eyebrowLabel}`}>
@@ -185,7 +185,15 @@ const VBC_TITLE = 'Why Value-Based Care is Harder Than Rocket Science';
     {showToc && <TableOfContents items={tocItems} />}
 
     {/* Content - React island for markdown rendering */}
-    <ContentRenderer content={post.content} client:load />
+    {
+      type === 'photos' ? (
+        <div class="photos-content">
+          <ContentRenderer content={post.content} client:load />
+        </div>
+      ) : (
+        <ContentRenderer content={post.content} client:load />
+      )
+    }
 
     {/* Footer slot for VBCFooter and PostsFooter */}
     <slot name="footer" />

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -188,7 +188,7 @@ const VBC_TITLE = 'Why Value-Based Care is Harder Than Rocket Science';
     {
       type === 'photos' ? (
         <div class="photos-content">
-          <ContentRenderer content={post.content} client:load />
+          <ContentRenderer content={post.content} gallery client:load />
         </div>
       ) : (
         <ContentRenderer content={post.content} client:load />

--- a/src/lib/notion-loader.ts
+++ b/src/lib/notion-loader.ts
@@ -78,7 +78,22 @@ export function notionLoader(options: NotionLoaderOptions): Loader {
           logger.warn(`Failed to download image: ${src}`);
         }
 
-        return `<figure><img src="/images/${filename}" /></figure>`;
+        // Notion image blocks carry an optional rich-text caption — surface it
+        // as a <figcaption> so gallery layouts can render a title beneath each
+        // photo. HTML-escape to keep the raw markdown string safe.
+        const captionText = image.caption
+          .map((rt) => rt.plain_text)
+          .join('')
+          .trim();
+        const escape = (s: string) =>
+          s
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+        const caption = captionText ? `<figcaption>${escape(captionText)}</figcaption>` : '';
+
+        return `<figure><img src="/images/${filename}" alt="${escape(captionText)}" />${caption}</figure>`;
       });
 
       // Custom transformer for column layouts

--- a/src/lib/notion-loader.ts
+++ b/src/lib/notion-loader.ts
@@ -12,6 +12,9 @@ import { NotionToMarkdown } from 'notion-to-md';
 
 import { downloadImage, getFilename } from './download-image';
 
+const escapeHtml = (s: string) =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
 export interface NotionLoaderOptions {
   /** Notion data source ID (database ID) */
   dataSourceId: string;
@@ -85,15 +88,9 @@ export function notionLoader(options: NotionLoaderOptions): Loader {
           .map((rt) => rt.plain_text)
           .join('')
           .trim();
-        const escape = (s: string) =>
-          s
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;');
-        const caption = captionText ? `<figcaption>${escape(captionText)}</figcaption>` : '';
+        const caption = captionText ? `<figcaption>${escapeHtml(captionText)}</figcaption>` : '';
 
-        return `<figure><img src="/images/${filename}" alt="${escape(captionText)}" />${caption}</figure>`;
+        return `<figure><img src="/images/${filename}" alt="${escapeHtml(captionText)}" />${caption}</figure>`;
       });
 
       // Custom transformer for column layouts

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -108,7 +108,22 @@ const jsonLd = {
     {
       posts.length > 0 && (
         <section id="writing">
-          <h2 class="resume-section-heading">Writing</h2>
+          <header class="bm-section-header">
+            <div class="bm-eyebrow" aria-label="Section 01, Writing">
+              <span class="bm-eyebrow-mark" aria-hidden="true">
+                &sect;
+              </span>
+              <span class="bm-eyebrow-num">01</span>
+              <span class="bm-eyebrow-sep" aria-hidden="true">
+                &middot;
+              </span>
+              <span class="bm-eyebrow-label">Writing</span>
+            </div>
+            <h2 class="bm-section-display-title">Recent Essays</h2>
+            <p class="bm-section-tagline">
+              Essays on engineering leadership, value-based care, and the craft of building.
+            </p>
+          </header>
           {vbcPosts.length > 0 && (
             <PostCard
               post={{
@@ -134,7 +149,23 @@ const jsonLd = {
     {
       photos.length > 0 && (
         <section id="photography">
-          <h2 class="resume-section-heading">Photography</h2>
+          <header class="bm-section-header">
+            <div class="bm-eyebrow" aria-label="Section 02, Photography">
+              <span class="bm-eyebrow-mark" aria-hidden="true">
+                &sect;
+              </span>
+              <span class="bm-eyebrow-num">02</span>
+              <span class="bm-eyebrow-sep" aria-hidden="true">
+                &middot;
+              </span>
+              <span class="bm-eyebrow-label">Photography</span>
+            </div>
+            <h2 class="bm-section-display-title">Recent Frames</h2>
+            <p class="bm-section-tagline">
+              A scanning analysis on hover &mdash; the photograph holds its quiet by default; the
+              system reveals itself when you lean in.
+            </p>
+          </header>
           <div class="homepage-photo-grid">
             {photos.slice(0, 8).map((post) => (
               <PhotoCard post={post.data} shouldHideText />

--- a/src/pages/photos/index.astro
+++ b/src/pages/photos/index.astro
@@ -1,7 +1,7 @@
 ---
 /**
  * Photos index page
- * Displays all photos in a responsive grid
+ * Two-column grid matching the homepage photo treatment.
  */
 
 import { getCollection } from 'astro:content';
@@ -16,15 +16,23 @@ const photos = (await getCollection('photos')).sort(
 
 <BaseLayout title="Photography" description="Photography by Brennan Moore.">
   <div class="max-w-[960px] mx-auto">
-    <header class="mb-8">
-      <h1 class="font-serif text-3xl font-semibold mb-2">Photography</h1>
+    <header class="bm-section-header">
+      <div class="bm-eyebrow" aria-label="Photography">
+        <span class="bm-eyebrow-mark" aria-hidden="true">&sect;</span>
+        <span class="bm-eyebrow-label">Photography</span>
+      </div>
+      <h1 class="bm-section-display-title">Recent Frames</h1>
+      <p class="bm-section-tagline">
+        A scanning analysis on hover &mdash; the photograph holds its quiet by default; the system
+        reveals itself when you lean in.
+      </p>
     </header>
 
     {
       photos.length > 0 && (
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div class="homepage-photo-grid">
           {photos.map((post) => (
-            <PhotoCard post={post.data} />
+            <PhotoCard post={post.data} shouldHideText />
           ))}
         </div>
       )

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1177,7 +1177,7 @@
   .photos-content .prose {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    gap: 2.5rem 1.5rem;
+    gap: 0.75rem 0.5rem;
     align-items: start;
     max-width: none;
     margin-bottom: 3rem;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1203,8 +1203,10 @@
     max-width: 960px;
   }
 
-  /* Photo post body — flow inline markdown images into a 2-column grid. */
-  .photos-content > .prose {
+  /* Photo post body — flow inline markdown images into a 2-column grid.
+     ContentRenderer hydrates inside an <astro-island> so we use descendant
+     combinators instead of direct-child to span that wrapper. */
+  .photos-content .prose {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: 0.375rem;
@@ -1212,21 +1214,21 @@
     margin-bottom: 3rem;
   }
 
-  .photos-content > .prose > * {
+  .photos-content .prose > * {
     margin: 0;
     max-width: none;
   }
 
   /* Each <figure> (or stray <p> wrapping an image) is one grid cell. */
-  .photos-content > .prose > figure,
-  .photos-content > .prose > p {
+  .photos-content .prose > figure,
+  .photos-content .prose > p {
     overflow: hidden;
     border-radius: var(--radius-sm, 2px);
   }
 
-  .photos-content > .prose > figure > img,
-  .photos-content > .prose > p > img,
-  .photos-content > .prose > img {
+  .photos-content .prose > figure > img,
+  .photos-content .prose > p > img,
+  .photos-content .prose > img {
     width: 100%;
     height: auto;
     display: block;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1209,7 +1209,8 @@
   .photos-content .prose {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    gap: 0.375rem;
+    gap: 2.5rem 1.5rem;
+    align-items: start;
     max-width: none;
     margin-bottom: 3rem;
   }
@@ -1219,11 +1220,11 @@
     max-width: none;
   }
 
-  /* Each <figure> (or stray <p> wrapping an image) is one grid cell. */
-  .photos-content .prose > figure,
-  .photos-content .prose > p {
-    overflow: hidden;
-    border-radius: var(--radius-sm, 2px);
+  /* Each <figure> is one grid cell; image fills natively, caption below. */
+  .photos-content .prose > figure {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
   }
 
   .photos-content .prose > figure > img,
@@ -1233,16 +1234,35 @@
     height: auto;
     display: block;
     margin: 0;
+    border-radius: var(--radius-sm, 2px);
   }
 
-  .photos-content figcaption {
-    font-family: var(--font-mono);
-    font-size: 0.68rem;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--muted-foreground);
-    margin-top: 0.375rem;
+  /* Caption row: italic serif title (left) + decorative mono coords (right) */
+  .photos-content .photos-cap {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
     text-align: left;
     padding: 0;
+    color: var(--foreground);
+  }
+
+  .photos-content .photos-cap .cap-title {
+    font-family: var(--font-serif);
+    font-style: italic;
+    font-weight: 400;
+    font-size: var(--font-size-base);
+    color: var(--foreground);
+    line-height: 1.3;
+  }
+
+  .photos-content .photos-cap .cap-coords {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.1em;
+    color: var(--muted-foreground);
+    white-space: nowrap;
+    flex-shrink: 0;
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1087,7 +1087,7 @@
     border-bottom-color: var(--accent);
   }
 
-  .post-title {
+  .post-header .post-title {
     font-family: var(--font-serif);
     font-size: clamp(2.25rem, 1.6rem + 2.2vw, 3.25rem);
     font-weight: 500;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1217,18 +1217,30 @@
     max-width: none;
   }
 
-  /* Unwrap paragraph/figure wrappers so their image children become direct
-     grid items — markdown can pack several images into one <p>. */
-  .photos-content > .prose > p,
-  .photos-content > .prose > figure {
-    display: contents;
+  /* Each <figure> (or stray <p> wrapping an image) is one grid cell. */
+  .photos-content > .prose > figure,
+  .photos-content > .prose > p {
+    overflow: hidden;
+    border-radius: var(--radius-sm, 2px);
   }
 
-  .photos-content img {
+  .photos-content > .prose > figure > img,
+  .photos-content > .prose > p > img,
+  .photos-content > .prose > img {
     width: 100%;
     height: auto;
     display: block;
     margin: 0;
-    border-radius: var(--radius-sm, 2px);
+  }
+
+  .photos-content figcaption {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--muted-foreground);
+    margin-top: 0.375rem;
+    text-align: left;
+    padding: 0;
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1023,4 +1023,107 @@
     outline-offset: 2px;
     border-radius: 2px;
   }
+
+  /* --------------------------------------------------------------------------
+     Post header — "Recent Frames" treatment
+     Copper eyebrow (§ NN · CATEGORY), serif title, italic muted subtitle,
+     monospace meta strip bracketed by hairline rules.
+     -------------------------------------------------------------------------- */
+  .post-header {
+    margin-bottom: 3rem;
+  }
+
+  .post-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--accent-bold);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .post-eyebrow-mark {
+    font-family: var(--font-serif);
+    font-style: italic;
+    font-size: 0.95rem;
+    letter-spacing: 0;
+    line-height: 1;
+    color: var(--accent-bold);
+  }
+
+  .post-eyebrow-num {
+    font-weight: 700;
+  }
+
+  .post-eyebrow-sep {
+    color: color-mix(in srgb, var(--accent-bold) 45%, transparent);
+  }
+
+  .post-eyebrow-label {
+    color: var(--accent-bold);
+  }
+
+  .post-series-link {
+    display: inline-block;
+    font-family: var(--font-sans);
+    font-size: var(--font-size-sm);
+    color: var(--muted-foreground);
+    border-bottom: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+    margin-bottom: 1.25rem;
+    transition: color var(--transition-fast) var(--ease-out),
+      border-color var(--transition-normal) var(--ease-out);
+  }
+
+  .post-series-link em {
+    font-family: var(--font-serif);
+    font-style: italic;
+  }
+
+  .post-series-link:hover {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+  }
+
+  .post-title {
+    font-family: var(--font-serif);
+    font-size: clamp(2.25rem, 1.6rem + 2.2vw, 3.25rem);
+    font-weight: 500;
+    line-height: 1.08;
+    letter-spacing: -0.01em;
+    color: var(--foreground);
+    margin: 0 0 1rem 0;
+  }
+
+  .post-subtitle {
+    font-family: var(--font-serif);
+    font-style: italic;
+    font-weight: 400;
+    font-size: clamp(1.125rem, 1rem + 0.4vw, 1.35rem);
+    line-height: 1.5;
+    color: var(--muted-foreground);
+    margin: 0 0 2rem 0;
+    max-width: 60ch;
+  }
+
+  .post-meta-strip {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--muted-foreground);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0.875rem 0;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .post-meta-strip .sep {
+    color: color-mix(in srgb, var(--muted-foreground) 40%, transparent);
+  }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1030,10 +1030,10 @@
      monospace meta strip bracketed by hairline rules.
      -------------------------------------------------------------------------- */
   .post-header {
-    margin-bottom: 3rem;
+    margin-bottom: 2.5rem;
   }
 
-  .post-eyebrow {
+  .post-header .post-eyebrow {
     font-family: var(--font-mono);
     font-size: 0.7rem;
     letter-spacing: 0.16em;
@@ -1042,28 +1042,27 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    margin-bottom: 1.5rem;
+    margin-bottom: 0.625rem;
   }
 
-  .post-eyebrow-mark {
+  .post-header .post-eyebrow > * {
+    color: var(--accent-bold);
+  }
+
+  .post-header .post-eyebrow-mark {
     font-family: var(--font-serif);
     font-style: italic;
     font-size: 0.95rem;
     letter-spacing: 0;
     line-height: 1;
-    color: var(--accent-bold);
   }
 
-  .post-eyebrow-num {
+  .post-header .post-eyebrow-num {
     font-weight: 700;
   }
 
-  .post-eyebrow-sep {
+  .post-header .post-eyebrow-sep {
     color: color-mix(in srgb, var(--accent-bold) 45%, transparent);
-  }
-
-  .post-eyebrow-label {
-    color: var(--accent-bold);
   }
 
   .post-series-link {
@@ -1094,7 +1093,7 @@
     line-height: 1.08;
     letter-spacing: -0.01em;
     color: var(--foreground);
-    margin: 0 0 1rem 0;
+    margin: 0 0 0.625rem 0;
   }
 
   .post-subtitle {
@@ -1104,7 +1103,7 @@
     font-size: clamp(1.125rem, 1rem + 0.4vw, 1.35rem);
     line-height: 1.5;
     color: var(--muted-foreground);
-    margin: 0 0 2rem 0;
+    margin: 0 0 1.5rem 0;
     max-width: 60ch;
   }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1188,7 +1188,8 @@
     max-width: none;
   }
 
-  /* Each <figure> is one grid cell; image fills natively, caption below. */
+  /* Each <figure> is one grid cell; cropped to a uniform 3:2 frame so
+     rows align horizontally regardless of source aspect ratio. */
   .photos-content .prose > figure {
     display: flex;
     flex-direction: column;
@@ -1199,7 +1200,9 @@
   .photos-content .prose > p > img,
   .photos-content .prose > img {
     width: 100%;
+    aspect-ratio: 3 / 2;
     height: auto;
+    object-fit: cover;
     display: block;
     margin: 0;
     border-radius: var(--radius-sm, 2px);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1187,4 +1187,39 @@
     margin: 0;
     max-width: 60ch;
   }
+
+  /* --------------------------------------------------------------------------
+     Post article wrapper — narrow column for writing, wider for photo galleries.
+     Overrides the base `article { max-width: 680px }` rule via class specificity.
+     -------------------------------------------------------------------------- */
+  .post-article {
+    width: 100%;
+    max-width: 42rem;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .post-article--photos {
+    max-width: 960px;
+  }
+
+  /* Photo post body — flow inline markdown images into a 2-column grid. */
+  .photos-content > .prose {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.375rem;
+    margin-bottom: 3rem;
+  }
+
+  .photos-content > .prose > p {
+    margin: 0;
+    max-width: none;
+  }
+
+  .photos-content img {
+    width: 100%;
+    height: auto;
+    display: block;
+    border-radius: var(--radius-sm, 2px);
+  }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1033,38 +1033,6 @@
     margin-bottom: 2.5rem;
   }
 
-  .post-header .post-eyebrow {
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    color: var(--accent-bold);
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.625rem;
-  }
-
-  .post-header .post-eyebrow > * {
-    color: var(--accent-bold);
-  }
-
-  .post-header .post-eyebrow-mark {
-    font-family: var(--font-serif);
-    font-style: italic;
-    font-size: 0.95rem;
-    letter-spacing: 0;
-    line-height: 1;
-  }
-
-  .post-header .post-eyebrow-num {
-    font-weight: 700;
-  }
-
-  .post-header .post-eyebrow-sep {
-    color: color-mix(in srgb, var(--accent-bold) 45%, transparent);
-  }
-
   .post-series-link {
     display: inline-block;
     font-family: var(--font-sans);
@@ -1237,12 +1205,8 @@
     border-radius: var(--radius-sm, 2px);
   }
 
-  /* Caption row: italic serif title (left) + decorative mono coords (right) */
+  /* Caption row: italic serif title beneath each photo */
   .photos-content .photos-cap {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 1rem;
     text-align: left;
     padding: 0;
     color: var(--foreground);
@@ -1257,12 +1221,11 @@
     line-height: 1.3;
   }
 
-  .photos-content .photos-cap .cap-coords {
-    font-family: var(--font-mono);
-    font-size: 0.65rem;
-    letter-spacing: 0.1em;
-    color: var(--muted-foreground);
-    white-space: nowrap;
-    flex-shrink: 0;
+  /* Collapse the photo-post grid to a single column on narrow viewports. */
+  @media (max-width: 640px) {
+    .photos-content .prose {
+      grid-template-columns: 1fr;
+      gap: 1.5rem;
+    }
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1168,7 +1168,11 @@
   }
 
   .post-article--photos {
-    max-width: 960px;
+    max-width: 1200px;
+  }
+
+  .photos-content {
+    margin-top: 2rem;
   }
 
   /* Photo post body — flow inline markdown images into a 2-column grid.
@@ -1184,16 +1188,28 @@
   }
 
   .photos-content .prose > * {
-    margin: 0;
+    margin: 0 !important;
     max-width: none;
+  }
+
+  /* Hoist figures out of any stray <p>/<br> wrappers ReactMarkdown may insert
+     between blocks — those would otherwise occupy their own grid rows and
+     create big visual gaps between photo rows. */
+  .photos-content .prose > p {
+    display: contents;
+  }
+  .photos-content .prose > br,
+  .photos-content .prose > p:empty {
+    display: none;
   }
 
   /* Each <figure> is one grid cell; cropped to a uniform square frame so
      rows align horizontally regardless of source aspect ratio. */
-  .photos-content .prose > figure {
+  .photos-content .prose figure {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.375rem;
+    margin: 0 !important;
   }
 
   .photos-content .prose > figure > img,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1188,7 +1188,7 @@
     max-width: none;
   }
 
-  /* Each <figure> is one grid cell; cropped to a uniform 3:2 frame so
+  /* Each <figure> is one grid cell; cropped to a uniform square frame so
      rows align horizontally regardless of source aspect ratio. */
   .photos-content .prose > figure {
     display: flex;
@@ -1200,7 +1200,7 @@
   .photos-content .prose > p > img,
   .photos-content .prose > img {
     width: 100%;
-    aspect-ratio: 3 / 2;
+    aspect-ratio: 1 / 1;
     height: auto;
     object-fit: cover;
     display: block;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1089,7 +1089,7 @@
 
   .post-header .post-title {
     font-family: var(--font-serif);
-    font-size: clamp(2.25rem, 1.6rem + 2.2vw, 3.25rem);
+    font-size: var(--font-size-4xl);
     font-weight: 500;
     line-height: 1.08;
     letter-spacing: -0.01em;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1208,18 +1208,27 @@
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: 0.375rem;
+    max-width: none;
     margin-bottom: 3rem;
   }
 
-  .photos-content > .prose > p {
+  .photos-content > .prose > * {
     margin: 0;
     max-width: none;
+  }
+
+  /* Unwrap paragraph/figure wrappers so their image children become direct
+     grid items — markdown can pack several images into one <p>. */
+  .photos-content > .prose > p,
+  .photos-content > .prose > figure {
+    display: contents;
   }
 
   .photos-content img {
     width: 100%;
     height: auto;
     display: block;
+    margin: 0;
     border-radius: var(--radius-sm, 2px);
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1072,7 +1072,8 @@
     color: var(--muted-foreground);
     border-bottom: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
     margin-bottom: 1.25rem;
-    transition: color var(--transition-fast) var(--ease-out),
+    transition:
+      color var(--transition-fast) var(--ease-out),
       border-color var(--transition-normal) var(--ease-out);
   }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1126,4 +1126,65 @@
   .post-meta-strip .sep {
     color: color-mix(in srgb, var(--muted-foreground) 40%, transparent);
   }
+
+  /* --------------------------------------------------------------------------
+     Section header — reusable "Recent Frames" treatment for homepage sections
+     and anywhere we want the copper § NN · LABEL eyebrow + italic tagline.
+     -------------------------------------------------------------------------- */
+  .bm-section-header {
+    margin-bottom: 1.75rem;
+  }
+
+  .bm-eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--accent-bold);
+    margin-bottom: 0.625rem;
+  }
+
+  .bm-eyebrow > * {
+    color: var(--accent-bold);
+  }
+
+  .bm-eyebrow-mark {
+    font-family: var(--font-serif);
+    font-style: italic;
+    font-size: 0.95rem;
+    line-height: 1;
+    letter-spacing: 0;
+  }
+
+  .bm-eyebrow-num {
+    font-weight: 700;
+  }
+
+  .bm-eyebrow-sep {
+    color: color-mix(in srgb, var(--accent-bold) 45%, transparent);
+  }
+
+  .bm-section-display-title {
+    font-family: var(--font-serif);
+    font-size: var(--font-size-3xl);
+    font-weight: 500;
+    line-height: 1.1;
+    letter-spacing: -0.005em;
+    color: var(--foreground);
+    margin: 0 0 0.5rem 0;
+  }
+
+  .bm-section-tagline {
+    font-family: var(--font-serif);
+    font-style: italic;
+    font-weight: 400;
+    font-size: var(--font-size-lg);
+    line-height: 1.5;
+    color: var(--muted-foreground);
+    margin: 0;
+    max-width: 60ch;
+  }
 }


### PR DESCRIPTION
## Summary
Adopts the \"Recent Frames\" header treatment for blog and photo post pages.

- Copper monospace **eyebrow** with section glyph + deterministic 2-digit number + category label (e.g. `§ 03 · ESSAY`). Number is a stable hash of the slug — decorative, in the same spirit as the inspect-treatment telemetry.
- Large serif **title** with slightly tightened leading and a touch of negative letter-spacing for a more bookish feel.
- Italic serif **subtitle** in muted color (replaces the existing section-subtitle style).
- Monospace **meta strip** bracketed by hairline rules, showing `CATEGORY · 2026.05.12 · 7 MIN READ · LAST UPDATED 2026.05.12`. Reading time only appears on writing posts.
- Replaces the loud teal VBC pill with a quieter inline `From the series: <em>…</em>` link that uses the standard accent underline.

Applies to every page using `PostLayout` (writing posts and photo posts).

## Test plan
- [ ] \`npm run check\` — 0 errors
- [ ] \`npm run lint\` — clean
- [ ] \`npm test\` — all tests pass
- [ ] Manual: visit any \`/writing/<slug>\` — eyebrow, title, italic subtitle, meta strip render correctly; reading time appears
- [ ] Manual: visit any \`/photos/<slug>\` — same treatment; reading time hidden
- [ ] Manual: a VBC post shows the \"From the series\" link instead of the pill
- [ ] Manual: meta strip wraps gracefully on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)