### PR TITLE
Sort VBC series card chronologically instead of pinning it

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,15 +30,22 @@ if (posts.length === 0 && vbcPosts.length === 0 && photos.length === 0) {
 
 const siteUrl = config.site.url;
 
-// Limit homepage writing to 5 total cards. When the VBC series card is
-// rendered above the post list, it claims one of those slots — so the
-// number of individual posts shown drops to 4.
+// Homepage writing list: the VBC series is shown as a single card that sorts
+// chronologically alongside individual posts (dated by its first part), rather
+// than being pinned to the top. Limit to 5 total cards.
 const HOMEPAGE_WRITING_CARDS = 5;
-const hasVbcCard = vbcPosts.length > 0;
-const recentPostsLimit = HOMEPAGE_WRITING_CARDS - (hasVbcCard ? 1 : 0);
-const recentPosts = posts
-  .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
-  .slice(0, recentPostsLimit);
+const vbcCard =
+  vbcPosts.length > 0
+    ? {
+        slug: vbcPosts[0].data.slug,
+        title: VBC_TITLE,
+        date: vbcPosts[0].data.date,
+        excerpt: `A ${vbcPosts.length}-part series on why fixing American healthcare from the inside is harder than it looks.`,
+      }
+    : null;
+const writingCards = [...posts.map((p) => p.data), ...(vbcCard ? [vbcCard] : [])]
+  .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+  .slice(0, HOMEPAGE_WRITING_CARDS);
 
 // Schema.org JSON-LD for homepage
 const jsonLd = {
@@ -128,20 +135,10 @@ const jsonLd = {
             <h2 class="bm-section-display-title">Recent Essays</h2>
             <p class="bm-section-tagline">How I got my gray hairs.</p>
           </header>
-          {vbcPosts.length > 0 && (
-            <PostCard
-              post={{
-                slug: vbcPosts[0].data.slug,
-                title: VBC_TITLE,
-                date: vbcPosts[0].data.date,
-                excerpt: `A ${vbcPosts.length}-part series on why fixing American healthcare from the inside is harder than it looks.`,
-              }}
-            />
-          )}
-          {recentPosts.map((post) => (
-            <PostCard post={post.data} />
+          {writingCards.map((post) => (
+            <PostCard post={post} />
           ))}
-          {posts.length > recentPosts.length && (
+          {posts.length + (vbcCard ? 1 : 0) > writingCards.length && (
             <a href="/writing" class="view-all-link">
               View all writing →
             </a>


### PR DESCRIPTION
## What

The homepage writing section pinned the **VBC series card** ("Why Value-Based Care is Harder Than Rocket Science") to the top unconditionally, so it appeared above newer posts regardless of date.

This folds the VBC card into the post list — dated by its first part (2025-07-27) — and sorts all cards by date descending, taking the top 5.

## Why

After publishing a new 2026 post, the VBC card still led the homepage because it was hardcoded first, which was confusing.

## Resulting order

| # | Date | Card |
|---|------|------|
| 1 | 2026-06-03 | AI memory is a filing system, not a file |
| 2 | 2025-07-27 | Why Value-Based Care is Harder Than Rocket Science (series) |
| 3 | 2022-07-02 | An introduction to building software for value-based care |
| 4 | 2022-04-30 | Learnings from building Kelp |
| 5 | 2021-10-25 | Learning from a Hyper-Growth Startup |

## Notes

- `npm run check` passes (0 errors)
- Card-count math preserved: still caps at 5 total cards
- Pure presentation change; no content or schema changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)