### PR TITLE
Add section eyebrows to all five homepage sections

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -184,6 +184,12 @@ const jsonLd = {
     <div>
       <section id="currently" class="currently-section">
         <header class="bm-section-header">
+          <div class="bm-eyebrow" aria-label="Section 03, Currently">
+            <span class="bm-eyebrow-mark" aria-hidden="true">&sect;</span>
+            <span class="bm-eyebrow-num">03</span>
+            <span class="bm-eyebrow-sep" aria-hidden="true">&middot;</span>
+            <span class="bm-eyebrow-label">Currently</span>
+          </div>
           <h2 class="bm-section-display-title">About Me</h2>
         </header>
         <p>
@@ -215,6 +221,12 @@ const jsonLd = {
 
       <section id="work">
         <header class="bm-section-header">
+          <div class="bm-eyebrow" aria-label="Section 04, Experience">
+            <span class="bm-eyebrow-mark" aria-hidden="true">&sect;</span>
+            <span class="bm-eyebrow-num">04</span>
+            <span class="bm-eyebrow-sep" aria-hidden="true">&middot;</span>
+            <span class="bm-eyebrow-label">Experience</span>
+          </div>
           <h2 class="bm-section-display-title">Selected Work</h2>
         </header>
 
@@ -288,6 +300,12 @@ const jsonLd = {
 
       <section id="publications">
         <header class="bm-section-header">
+          <div class="bm-eyebrow" aria-label="Section 05, Publications">
+            <span class="bm-eyebrow-mark" aria-hidden="true">&sect;</span>
+            <span class="bm-eyebrow-num">05</span>
+            <span class="bm-eyebrow-sep" aria-hidden="true">&middot;</span>
+            <span class="bm-eyebrow-label">Publications</span>
+          </div>
           <h2 class="bm-section-display-title">HCI Publications</h2>
         </header>
         <div class="publication-intro">


### PR DESCRIPTION
## Summary

The homepage tracks five sections in the right-side `SectionRail` nav (01–05), but only Writing (01) and Photography (02) had the inline `§ NN · LABEL` eyebrow. The three resume-style sections below them rendered with bare headings.

This adds matching eyebrows to the remaining three so all five sections are numbered consistently with the rail:

| # | Eyebrow label (matches rail) | Heading |
|---|------------------------------|---------|
| 01 | Writing | Recent Essays |
| 02 | Photography | Recent Photos |
| 03 | Currently | About Me |
| 04 | Experience | Selected Work |
| 05 | Publications | HCI Publications |

## Notes

- Reuses the existing `bm-eyebrow` markup/CSS (§ mark, number, `·` separator, label).
- Each eyebrow carries an `aria-label="Section NN, …"` for screen readers.
- Eyebrow labels use the rail's wording while headings keep their own (e.g. eyebrow "Currently" + heading "About Me") — same pattern 01/02 already used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)