### PR TITLE
Address code-block review: contrast, CSP comment, Prism tokens, lint

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -87,8 +87,14 @@ export default defineConfig({
         resources: ["'self'", 'https://static.cloudflareinsights.com'],
       },
       styleDirective: {
-        // 'unsafe-inline' covers React-emitted <style> tags and inline
-        // style="..." attributes that Astro's hasher doesn't see.
+        // 'self' + fonts.googleapis.com cover external stylesheets. Note that
+        // 'unsafe-inline' is effectively INERT here: Astro appends sha256
+        // hashes for its own inline <style> tags, and per the CSP spec a
+        // present hash makes 'unsafe-inline' ignored — including for
+        // style="..." attributes. Inline styles are therefore blocked; theme
+        // code blocks via CSS classes, not inline styles (see
+        // TableOfContents.astro / ContentRenderer.tsx). Kept only as a no-op
+        // fallback for any page that ships no hashed inline style.
         resources: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
       },
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,9 @@ const eslintConfig = [
   {
     rules: {
       '@typescript-eslint/no-require-imports': 'off',
+      // Allow dropping a prop via a rest sibling, e.g.
+      // `function CodeTag({ style, ...rest })` in ContentRenderer.tsx.
+      '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
     },
   },
   {

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -28,6 +28,9 @@ const minLevel = Math.min(...items.map((item) => item.level));
 // site's CSP blocks inline `style` attributes: Astro auto-hashes its own inline
 // <style> tags, and per the CSP spec a present hash makes 'unsafe-inline' inert.
 // Class names must be written as full literals so Tailwind detects them.
+// Five indent steps cover h1→h5 relative to the shallowest heading. Anything
+// deeper (a lone h6 under an h1) is intentionally capped at ml-16 rather than
+// growing unbounded — article ToCs effectively never nest that deep.
 const indentClasses = ['ml-0', 'ml-4', 'ml-8', 'ml-12', 'ml-16'];
 const indentFor = (level: number) =>
   indentClasses[Math.min(level - minLevel, indentClasses.length - 1)];

--- a/src/components/islands/ContentRenderer.tsx
+++ b/src/components/islands/ContentRenderer.tsx
@@ -21,7 +21,7 @@ interface ContentRendererProps {
 // `white-space:pre` style. The CSP blocks inline styles, and `.code-block`
 // already supplies `white-space: pre` (inherited by this <code>), so the
 // inline style is both blocked and redundant.
-function CodeTag({ style: _style, ...rest }: React.HTMLAttributes<HTMLElement>) {
+function CodeTag({ style, ...rest }: React.HTMLAttributes<HTMLElement>) {
   return <code {...rest} />;
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -511,7 +511,7 @@
   .code-block .token.atrule,
   .code-block .token.rule,
   .code-block .token.important {
-    color: #a85a36; /* darkened copper */
+    color: #8f4c2e; /* darkened copper — WCAG AA on --muted (~5.4:1) */
     font-weight: 600;
   }
 
@@ -526,7 +526,7 @@
   .code-block .token.char,
   .code-block .token.attr-value,
   .code-block .token.regex {
-    color: #4f7d5f; /* darkened success green */
+    color: #436a51; /* darkened success green — WCAG AA on --muted (~5.1:1) */
   }
 
   .code-block .token.number,
@@ -540,6 +540,25 @@
   .code-block .token.property,
   .code-block .token.attr-name {
     color: #3f5d8a; /* deep indigo-blue */
+  }
+
+  /* CSS custom properties, shell/template variables, TS namespaces, XML
+     prefixes. Without these Prism falls back to --foreground (readable but
+     undifferentiated). Reuse existing AA-passing token hues. */
+  .code-block .token.variable {
+    color: #2f6d80; /* deep teal — matches number/constant family */
+  }
+
+  .code-block .token.namespace {
+    color: #46627a; /* darkened steel blue — matches class-name family */
+  }
+
+  .code-block .token.template-string {
+    color: #436a51; /* darkened success green — matches string family */
+  }
+
+  .code-block .token.template-punctuation {
+    color: var(--muted-foreground); /* matches punctuation */
   }
 
   .code-block .token.deleted {


### PR DESCRIPTION
Follow-up to #944 addressing review findings on the code-block styling work.

## Changes

**Accessibility — WCAG 2.1 AA contrast (verified failing, fixed)**
Computed contrast ratios against the `#e8eaed` (`--muted`) code-block background. Two token colors failed the 4.5:1 threshold:
- `keyword` `#a85a36` (4.17:1) → `#8f4c2e` (~5.4:1)
- `string` `#4f7d5f` (3.93:1) → `#436a51` (~5.1:1)

Hue preserved. The remaining four token colors pass and were left unchanged.

**CSP comment correction (`astro.config.mjs`)**
The `styleDirective` comment claimed `'unsafe-inline'` covers inline `style="..."` attributes. That's wrong: Astro appends `sha256` hashes for its own inline `<style>` tags, and per the CSP spec a present hash makes `'unsafe-inline'` inert — including for style attributes. Rewrote the comment to state this accurately. Left `'unsafe-inline'` in place as a documented no-op rather than silently changing the security policy.

**Missing Prism token classes (`globals.css`)**
Added `.token.variable`, `.token.namespace`, `.token.template-string`, and `.token.template-punctuation`, each mapped to an existing AA-passing hue from the matching token family. These previously fell back to `--foreground` with no color differentiation.

**TableOfContents indentation cap**
Annotated the `ml-16` cap as intentional (no behavior change).

**Linting**
ESLint failed on the pre-existing `_style` discard in `CodeTag`. Enabled `no-unused-vars` `ignoreRestSiblings` (the option purpose-built for dropping a prop via a rest sibling) and simplified `{ style: _style, ... }` back to `{ style, ... }`.

## Verification
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run check` — 0 errors, 0 warnings
- `npm run check:design-tokens` — in sync
- `npm test` — 225 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)