### PR TITLE
fix: move inline styles to CSS classes for CSP compliance

### DIFF
--- a/src/components/islands/particles/renderer/create-renderer.ts
+++ b/src/components/islands/particles/renderer/create-renderer.ts
@@ -30,10 +30,10 @@ export function createRenderer(parent: HTMLElement, dpr: number): RendererBundle
   gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA); // premultiplied alpha
 
   const canvas = gl.canvas;
-  canvas.style.position = 'absolute';
-  canvas.style.inset = '0';
-  canvas.style.width = '100%';
-  canvas.style.height = '100%';
+  // Positioned via a CSS class rather than element.style — the CSP blocks
+  // inline styles (Astro's hashes make 'unsafe-inline' inert). See .particles-canvas
+  // in globals.css.
+  (canvas as HTMLCanvasElement).classList.add('particles-canvas');
   parent.appendChild(canvas);
 
   const resize = (width: number, height: number) => {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -108,7 +108,7 @@ const canonical = canonicalUrl || Astro.url.href;
         Canonical source: design-system/bm-filters.svg. Keep this block in sync
         with that file when tuning the edge-detection pipeline. */
     }
-    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+    <svg width="0" height="0" class="bm-filter-svg" aria-hidden="true">
       <defs>
         <filter
           id="bm-edge"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1094,6 +1094,21 @@
    ========================================================================== */
 
 @layer components {
+  /* Off-screen SVG holding the #bm-edge filter def. Positioned via class
+     (not a style="" attr) because the CSP blocks inline styles. */
+  .bm-filter-svg {
+    position: absolute;
+  }
+
+  /* FloatingParticles WebGL canvas. Applied via className instead of
+     element.style to satisfy the CSP (inline styles are blocked). */
+  .particles-canvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+
   .section-wrapper {
     /* Break out of parent container for full-bleed */
     width: 100vw;


### PR DESCRIPTION
## Problem

The browser console reported a CSP violation:

> Applying inline style violates the following Content Security Policy directive 'style-src ... 'sha256-...''. Note that 'unsafe-inline' is ignored if either a hash or nonce value is present in the source list. The action has been blocked.

Astro's auto-generated `sha256` hashes for its inline `<style>` tags make `'unsafe-inline'` **inert** — which also blocks `style="..."` attributes and runtime `element.style` assignments.

## Two sources of inline styles

1. **`create-renderer.ts`** — the FloatingParticles WebGL canvas set `canvas.style.position/inset/width/height` at runtime (this triggered the runtime "Applying inline style" violation).
2. **`BaseLayout.astro`** — the off-screen `#bm-edge` filter SVG used `style="position:absolute"`.

## Fix

Both now use CSS classes (`.particles-canvas`, `.bm-filter-svg`) added to `globals.css` under `@layer components`.

## Verification

- `npm run typecheck` passes
- Particle tests pass (18/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)