### PR TITLE
fix: suppress photo inspect hover overlay on touch devices

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -995,6 +995,26 @@
     transform: translateY(0);
   }
 
+  /* Touch devices (iOS Safari, etc.) have no true hover: a tap latches the
+     :hover state, revealing the #bm-edge line-art overlay whose edge-detection
+     convolution paints an outline around the photo. The inspect treatment is a
+     desktop hover affordance only — suppress the reveal on coarse pointers so
+     touch users see a clean static image. */
+  @media (hover: none), (pointer: coarse) {
+    .bm-photo--inspect:hover .bm-photo-base {
+      filter: none;
+    }
+    .bm-photo--inspect:hover .bm-photo-line {
+      opacity: 0;
+    }
+    .bm-photo--inspect:hover::before,
+    .bm-photo--inspect:hover .bm-hud-brackets span,
+    .bm-photo--inspect:hover .bm-hud-reticle,
+    .bm-photo--inspect:hover .bm-hud-telemetry {
+      opacity: 0;
+    }
+  }
+
   /* Tighter post cards in homepage primary section */
   .homepage-primary .post {
     margin-top: 0;


### PR DESCRIPTION
## Problem

On iOS Safari, photo cards showed an odd outline around the image on tap.

Every photo card renders with the `.bm-photo--inspect` treatment (`PhotoCard.astro`): a second stacked `<img class="bm-photo-line">` fades in on hover carrying the `#bm-edge` SVG filter — a `feConvolveMatrix` edge-detection kernel whose purpose is drawing outlines, which at the photo's perimeter paints an outline around the image.

That's the intended desktop hover "inspect" effect. But iOS Safari has no true hover: tapping the card (a link) latches `:hover`, revealing the edge-detect overlay + HUD and leaving the outline stuck on the image. The stylesheet had no `@media (hover)` guards, so nothing suppressed it on touch.

## Fix

Added a guard in `src/styles/globals.css` that neutralizes the inspect reveal (edge overlay, grid, HUD) on coarse/touch pointers via `@media (hover: none), (pointer: coarse)`. Touch users now see the clean static photo; desktop hover behavior is untouched.

## Testing

Verify on-device: open the photos page on an iPhone (or Safari Responsive Design Mode with a touch device) and confirm tapping a photo card no longer shows the outline/HUD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)