### PR TITLE
polish: align article-body typography to design tokens

### DIFF
--- a/__tests__/lib/utils.test.ts
+++ b/__tests__/lib/utils.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { calculateReadingTime, stripLeadingTitleHeading } from '../../src/lib/utils';
+
+describe('calculateReadingTime', () => {
+  it('rounds up to whole minutes at 225 wpm', () => {
+    expect(calculateReadingTime(0)).toBe('0 min read');
+    expect(calculateReadingTime(1)).toBe('1 min read');
+    expect(calculateReadingTime(225)).toBe('1 min read');
+    expect(calculateReadingTime(226)).toBe('2 min read');
+  });
+});
+
+describe('stripLeadingTitleHeading', () => {
+  const title = 'A workout planner for endurance + weight training';
+
+  it('removes a leading H1 that repeats the title', () => {
+    const content = `# ${title}\n\nAs I've gotten older...`;
+    expect(stripLeadingTitleHeading(content, title)).toBe("As I've gotten older...");
+  });
+
+  it('removes several consecutive duplicate title headings', () => {
+    const content = `\n# ${title}\n\n\n# ${title}\n\n\nBody starts here.`;
+    expect(stripLeadingTitleHeading(content, title)).toBe('Body starts here.');
+  });
+
+  it('matches case- and whitespace-insensitively', () => {
+    const content = `#   a WORKOUT planner   for endurance + weight training\n\nBody.`;
+    expect(stripLeadingTitleHeading(content, title)).toBe('Body.');
+  });
+
+  it('leaves a non-matching leading heading untouched', () => {
+    const content = `# A different heading\n\nBody.`;
+    expect(stripLeadingTitleHeading(content, title)).toBe(content);
+  });
+
+  it('does not strip a matching heading that appears after body content', () => {
+    const content = `Intro paragraph.\n\n# ${title}\n\nMore.`;
+    expect(stripLeadingTitleHeading(content, title)).toBe(content);
+  });
+
+  it('ignores deeper headings with the same text', () => {
+    const content = `## ${title}\n\nBody.`;
+    expect(stripLeadingTitleHeading(content, title)).toBe(content);
+  });
+
+  it('returns content unchanged when the title is empty', () => {
+    const content = `# ${title}\n\nBody.`;
+    expect(stripLeadingTitleHeading(content, '')).toBe(content);
+  });
+});

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -9,7 +9,7 @@ import type { TocItem } from '../components/TableOfContents.astro';
 import TableOfContents from '../components/TableOfContents.astro';
 import { config } from '../lib/config';
 import { extractHeadings } from '../lib/toc';
-import { calculateReadingTime } from '../lib/utils';
+import { calculateReadingTime, stripLeadingTitleHeading } from '../lib/utils';
 import BaseLayout from './BaseLayout.astro';
 
 interface PostData {
@@ -32,6 +32,11 @@ interface Props {
 }
 
 const { post, type = 'writing' } = Astro.props;
+
+// Notion bodies repeat the title as a leading H1, which would render the
+// headline twice (layout <h1> + body heading). Drop it for the rendered
+// article only; wordCount/JSON-LD below still use the canonical raw content.
+const bodyContent = stripLeadingTitleHeading(post.content, post.title);
 
 const postDate = new Date(post.date);
 const siteUrl = config.site.url;
@@ -200,10 +205,10 @@ const VBC_TITLE = 'Why Value-Based Care is Harder Than Rocket Science';
     {
       type === 'photos' ? (
         <div class="photos-content">
-          <ContentRenderer content={post.content} gallery client:load />
+          <ContentRenderer content={bodyContent} gallery client:load />
         </div>
       ) : (
-        <ContentRenderer content={post.content} client:load />
+        <ContentRenderer content={bodyContent} client:load />
       )
     }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -10,3 +10,42 @@ export function calculateReadingTime(wordCount: number): string {
   const minutes = Math.ceil(wordCount / WORDS_PER_MINUTE);
   return `${minutes} min read`;
 }
+
+/**
+ * Notion posts conventionally begin their body with an H1 that repeats the
+ * post title, so the rendered article shows the headline twice (the layout's
+ * `<h1>` plus a body heading). Strip a leading top-level heading — or several
+ * consecutive ones — that matches the title, leaving legitimate body headings
+ * untouched. Only the HTML article calls this; the raw `.md` and feeds keep the
+ * original source. Returns the content unchanged when nothing matches.
+ */
+export function stripLeadingTitleHeading(content: string, title: string): string {
+  const normalize = (s: string) =>
+    s
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, ' ');
+  const target = normalize(title);
+  if (!target) return content;
+
+  const lines = content.split('\n');
+  let cursor = 0;
+  let removed = false;
+  while (cursor < lines.length) {
+    const line = lines[cursor].trim();
+    if (line === '') {
+      cursor++;
+      continue;
+    }
+    const heading = /^#\s+(.+)$/.exec(line);
+    if (heading && normalize(heading[1]) === target) {
+      cursor++;
+      removed = true;
+      continue;
+    }
+    break;
+  }
+
+  if (!removed) return content;
+  return lines.slice(cursor).join('\n').replace(/^\n+/, '');
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,11 +20,7 @@ export function calculateReadingTime(wordCount: number): string {
  * original source. Returns the content unchanged when nothing matches.
  */
 export function stripLeadingTitleHeading(content: string, title: string): string {
-  const normalize = (s: string) =>
-    s
-      .trim()
-      .toLowerCase()
-      .replace(/\s+/g, ' ');
+  const normalize = (s: string) => s.trim().toLowerCase().replace(/\s+/g, ' ');
   const target = normalize(title);
   if (!target) return content;
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1912,3 +1912,54 @@
     }
   }
 }
+
+/* ============================================================================
+   Article body typography — override Tailwind Typography (`.prose`)
+
+   Tailwind's typography plugin registers `prose` in a later cascade layer than
+   `@layer components`, so its heading font-size/weight/line-height win over any
+   layered rule regardless of specificity. Its defaults render in-body headings
+   at weight 500 with loose leading on an em-based scale disconnected from our
+   `--font-size-*` tokens, flattening the hierarchy (section heads land only
+   ~1.2x the body size). These UNLAYERED rules (which beat every @layer) rebind
+   the article body to the site's committed serif scale for long-form reading.
+   `ContentRenderer` demotes headings one level (md `##` -> h3), so h3 is the
+   primary in-body section head and carries the strongest treatment. Scoped to
+   writing articles; photo galleries keep their own `.prose` treatment.
+   ============================================================================ */
+.post-article:not(.post-article--photos) .prose {
+  font-size: var(--article-font-size);
+  line-height: var(--line-height-body);
+}
+
+.post-article:not(.post-article--photos) .prose :is(p, li) {
+  line-height: var(--line-height-body);
+}
+
+.post-article:not(.post-article--photos) .prose :is(h2, h3, h4) {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  text-wrap: balance;
+}
+
+.post-article:not(.post-article--photos) .prose h2 {
+  font-size: var(--font-size-2xl); /* Fluid: 24-30px — matches site h2 token */
+  line-height: 1.2;
+  margin-top: 2.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.post-article:not(.post-article--photos) .prose h3 {
+  font-size: var(--font-size-xl); /* Fluid: 20-24px — matches site h3 token */
+  line-height: 1.25;
+  margin-top: 2.25rem;
+  margin-bottom: 0.4rem;
+}
+
+.post-article:not(.post-article--photos) .prose h4 {
+  font-size: var(--font-size-lg); /* Fluid: 18-20px — matches site h4 token */
+  line-height: 1.35;
+  letter-spacing: -0.005em;
+  margin-top: 1.75rem;
+  margin-bottom: 0.35rem;
+}


### PR DESCRIPTION
## Summary

Polishes the typography on writing posts (e.g. `/writing/intervals-icu-workout-planner/`). The article body (`.prose`) was styled entirely by **Tailwind Typography defaults**, disconnected from the site's design tokens — section headings rendered at **weight 500** with **loose leading (1.6)**, only **~1.2× the body size**, giving a flat, weak hierarchy (the "font sizes feel off" symptom).

## Changes

- **`src/styles/globals.css`** — add an *unlayered* `.prose` override block. Tailwind's typography plugin sits in a later cascade layer than `@layer components`, so layered rules can't win regardless of specificity; unlayered rules do. Rebinds article headings to the site's own token scale (`--font-size-2xl/xl/lg`) at **weight 600** with tight leading, and tightens body leading to `--line-height-body` (1.7). Scoped to writing articles so photo galleries keep their treatment.
  - New hierarchy: body 18.7px → h3 **23.8px** → h2 **28.9px** (weight 600), all clearly stepped and below the 43.5px page title.
- **`src/lib/utils.ts`** — add `stripLeadingTitleHeading()`. Notion bodies open with an H1 repeating the post title, so the headline rendered **twice** back-to-back (one post had it three times). Strips a leading title-matching H1 (case/whitespace-insensitive; leaves genuine headings alone).
- **`src/layouts/PostLayout.astro`** — apply the strip to the **rendered article only**; raw `.md`, RSS, and JSON-LD keep the canonical source.
- **`__tests__/lib/utils.test.ts`** — 8 tests covering the strip logic and reading-time.

## Verification

- Full suite: **233 passed / 2 skipped**
- `npm run typecheck`, `npm run check` (0 errors), `npm run lint`, `npm run check:design-tokens` — all clean
- Confirmed via before/after headless screenshots of the live post

## Not included

- **Body font family** stays Lato (sans) — the system deliberately pairs sans body with EB Garamond headings/title/subtitle.
- Pre-existing `blockquote { border-left: 4px }` (globals.css:436) is unrelated to this pass and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)