### PR TITLE
fix: keep article TOC and reading time in sync with stripped body

### DIFF
--- a/__tests__/lib/utils.test.ts
+++ b/__tests__/lib/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { extractHeadings } from '../../src/lib/toc';
 import { calculateReadingTime, stripLeadingTitleHeading } from '../../src/lib/utils';
 
 describe('calculateReadingTime', () => {
@@ -29,6 +30,11 @@ describe('stripLeadingTitleHeading', () => {
     expect(stripLeadingTitleHeading(content, title)).toBe('Body.');
   });
 
+  it('matches a heading wrapped in bold/emphasis markers', () => {
+    const content = `# **${title}**\n\nBody.`;
+    expect(stripLeadingTitleHeading(content, title)).toBe('Body.');
+  });
+
   it('leaves a non-matching leading heading untouched', () => {
     const content = `# A different heading\n\nBody.`;
     expect(stripLeadingTitleHeading(content, title)).toBe(content);
@@ -47,5 +53,16 @@ describe('stripLeadingTitleHeading', () => {
   it('returns content unchanged when the title is empty', () => {
     const content = `# ${title}\n\nBody.`;
     expect(stripLeadingTitleHeading(content, '')).toBe(content);
+  });
+
+  it('keeps TOC extraction in sync — the stripped title is not a heading', () => {
+    // PostLayout feeds bodyContent to both the renderer and extractHeadings;
+    // the duplicate-title H1 must be gone from both so no phantom TOC anchor
+    // (linking to a now-missing element) is produced.
+    const content = `# ${title}\n\n## Real section\n\nBody.\n\n### Subsection\n\nMore.`;
+    const body = stripLeadingTitleHeading(content, title);
+    const headings = extractHeadings(body);
+    expect(headings.map((h) => h.text)).toEqual(['Real section', 'Subsection']);
+    expect(headings.some((h) => h.text === title)).toBe(false);
   });
 });

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -34,8 +34,10 @@ interface Props {
 const { post, type = 'writing' } = Astro.props;
 
 // Notion bodies repeat the title as a leading H1, which would render the
-// headline twice (layout <h1> + body heading). Drop it for the rendered
-// article only; wordCount/JSON-LD below still use the canonical raw content.
+// headline twice (layout <h1> + body heading). Strip it, then derive
+// everything about the rendered article — markup, TOC, word count — from this
+// so they stay in sync. Only the raw `.md` endpoint and RSS/JSON feeds keep
+// the canonical unstripped source.
 const bodyContent = stripLeadingTitleHeading(post.content, post.title);
 
 const postDate = new Date(post.date);

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -64,16 +64,19 @@ const hasMeaningfulModified =
   !!post.dateModified && post.dateModified.split('T')[0] !== post.date.split('T')[0];
 const lastUpdatedLabel = hasMeaningfulModified ? formatIsoDate(post.dateModified) : '';
 
-// Calculate reading time
-const wordCount = post.content
+// Calculate reading time. Use `bodyContent` (the actually-rendered article)
+// so a stripped duplicate-title heading isn't counted.
+const wordCount = bodyContent
   .replace(/[^\w\s]/g, ' ')
   .replace(/\s+/g, ' ')
   .trim()
   .split(' ').length;
 const readingTime = calculateReadingTime(wordCount);
 
-// Extract TOC items if enabled
-const tocItems: TocItem[] = post.showToc ? extractHeadings(post.content) : [];
+// Extract TOC items if enabled. Read from `bodyContent`, not the raw content,
+// so the TOC stays in sync with the rendered DOM — otherwise a stripped
+// duplicate-title H1 would produce a phantom entry linking to a missing anchor.
+const tocItems: TocItem[] = post.showToc ? extractHeadings(bodyContent) : [];
 const showToc = post.showToc && tocItems.length >= 3;
 
 // Generate JSON-LD

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,7 +20,10 @@ export function calculateReadingTime(wordCount: number): string {
  * original source. Returns the content unchanged when nothing matches.
  */
 export function stripLeadingTitleHeading(content: string, title: string): string {
-  const normalize = (s: string) => s.trim().toLowerCase().replace(/\s+/g, ' ');
+  // Strip inline emphasis/code markers so a `# **Title**` heading still matches
+  // a plain frontmatter title, mirroring how extractHeadings() normalizes text.
+  const normalize = (s: string) =>
+    s.trim().replace(/[*_`]/g, '').replace(/\s+/g, ' ').toLowerCase();
   const target = normalize(title);
   if (!target) return content;
 


### PR DESCRIPTION
## Summary

Follow-up to #960, which merged before this fix could land. The automated review on #960 correctly flagged a bug that shipped to `main`:

`PostLayout.astro` renders the **stripped** `bodyContent` (with the duplicate-title H1 removed) but still built the TOC and reading time from the **raw** `post.content`. On posts whose Notion body opens with a title-matching `# Title` — exactly the posts #960 targets — this leaves:

- a **phantom TOC entry** linking to `#<title-slug>`, an anchor that no longer exists in the DOM (dead/no-op click);
- **skewed indentation**, since `TableOfContents`' `minLevel` picks up the phantom `level: 1` as its baseline;
- a possible **flipped TOC-visibility** (the `>= 3` heading threshold).

## Changes

- **`src/layouts/PostLayout.astro`** — build `tocItems` and `wordCount` from `bodyContent` so the TOC and reading time match the rendered article.
- **`src/lib/utils.ts`** — `normalize()` in `stripLeadingTitleHeading()` now strips inline emphasis/code markers (`*` `_` `` ` ``) so a `# **Title**` heading still matches a plain frontmatter title, mirroring `extractHeadings()`.
- **`__tests__/lib/utils.test.ts`** — add tests for the bold-wrapped title and a TOC-in-sync assertion (`extractHeadings(bodyContent)` no longer contains the title).

## Verification

- `lint`, `format:check`, `typecheck`, `check:design-tokens`, `knip`, `npm audit`, and the full vitest suite (**237 passing**) all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)