### PR TITLE
fix: match article list markers to the body ink

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1930,6 +1930,12 @@
 .post-article:not(.post-article--photos) .prose {
   font-size: var(--article-font-size);
   line-height: var(--line-height-body);
+  /* Tailwind Typography colors list markers lighter than body text via
+     --tw-prose-bullets (slate-300) and --tw-prose-counters (slate-500), so
+     bullets/numbers read as a different, paler gray than their text. Bind both
+     to the site ink so markers match the list text they belong to. */
+  --tw-prose-bullets: var(--foreground);
+  --tw-prose-counters: var(--foreground);
 }
 
 .post-article:not(.post-article--photos) .prose :is(p, li) {


### PR DESCRIPTION
## Summary

Article list markers (bullets and numbers) rendered a different, paler color than the list text beside them.

**Cause:** the content is rendered with Tailwind Typography (`prose prose-slate`), which deliberately colors markers lighter than body text via `--tw-prose-bullets` (slate‑300, L≈87%) and `--tw-prose-counters` (slate‑500, L≈55%). The `ContentRenderer` wrapper overrides paragraph color but never the marker variables, so numbers rendered ~18% lighter than their text and bullets were paler still.

**Fix:** bind both marker variables to `--foreground` in the existing unlayered `.prose` override block, so markers match the list-text ink.

| | Before | After |
|---|---|---|
| Numbers | `oklch(0.554…)` (L 55%) | `#2c333a` (`--foreground`) |
| Bullets | `oklch(0.869…)` (L 87%) | `#2c333a` (`--foreground`) |

Verified with headless computed-style measurement (markers now `rgb(44,51,58)`, matching the dark slate list text) and a rendered screenshot of an ordered list.

## Verification

- `lint`, `format:check`, `typecheck`, `check:design-tokens`, and the full vitest suite all pass locally.
- CSS-only change; no token additions (no `design-system/` drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)